### PR TITLE
Update gemspec to not rely on `git` executable

### DIFF
--- a/emoji.gemspec
+++ b/emoji.gemspec
@@ -8,7 +8,9 @@ Gem::Specification.new do |s|
   s.email    = "support@github.com"
   s.homepage = "https://github.com/github/emoji"
 
-  s.files = `git ls-files`.split("\n")
+  s.files  = %w(README.md Rakefile)
+  s.files += Dir.glob("images/**/*")
+  s.files += Dir.glob("lib/**/*")
 
   s.add_development_dependency "sprockets", "~> 2.0"
 end


### PR DESCRIPTION
- This prevents runtime issues when this gem is vendored in an
  application running on systems that don't have git installed
- See github/enterprise-web#685
