### PR TITLE
Remove railtie group

### DIFF
--- a/lib/emoji/railtie.rb
+++ b/lib/emoji/railtie.rb
@@ -7,7 +7,7 @@ module Emoji
       load "tasks/emoji.rake"
     end
 
-    initializer :emoji, :group => :assets do |app|
+    initializer :emoji do |app|
       app.config.assets.paths << Emoji.images_path
     end
   end


### PR DESCRIPTION
This basically reverts 91a5a025. Otherwise the gemoji images directory won't be added to the assets path.
