### PR TITLE
Convert to Railtie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,19 @@
 gemoji
 ======
-
 Emoji images and names. See the LICENSE for copyright information.
 
 
 Installation
-============
-
-Add `gemoji` to you Gemfile.
+------------
+Add `gemoji` to you Gemfile
 
 ``` ruby
-gem 'gemoji', :require => 'emoji/railtie'
+gem 'gemoji'
 ```
 
 
 Example Rails Helper
-====================
-
+--------------------
 This would allow emojifying content such as: `it's raining :cats: and :dogs:!`
 
 See the [Emoji cheat sheet](http://www.emoji-cheat-sheet.com) for more examples.
@@ -26,7 +23,7 @@ module EmojiHelper
  def emojify(content)
     h(content).to_str.gsub(/:([a-z0-9\+\-_]+):/) do |match|
       if Emoji.names.include?($1)
-        '<img alt="' + $1 + '" height="20" src="' + asset_path("emoji/#{$1}.png") + '" style="vertical-align:middle" width="20" />'
+        image_tag asset_path("emoji/#{$1}.png"), :alt => $1, :size => '20x20', :style => 'vertical-align: middle'
       else
         match
       end

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,9 @@
-desc "Checks for missing aliases to unicode sources"
+require 'bundler/gem_tasks'
+
+desc 'Checks for missing aliases to unicode sources'
 task :unnamed do
-  unicodes = Dir["./images/emoji/unicode/*.png"].map { |fn| File.basename(fn) }
-  aliases = Dir["./images/emoji/*.png"].select { |fn| File.symlink?(fn) }.map { |fn| File.basename(fn) }
+  unicodes = Dir['./images/emoji/unicode/*.png'].map { |fn| File.basename(fn) }
+  aliases = Dir['./images/emoji/*.png'].select { |fn| File.symlink?(fn) }.map { |fn| File.basename(fn) }
   used_unicodes = aliases.map { |name| File.basename(File.readlink("./images/emoji/#{name}")) }.uniq
   puts unicodes - used_unicodes
 end

--- a/gemoji.gemspec
+++ b/gemoji.gemspec
@@ -1,12 +1,18 @@
+# encoding: utf-8
+$:.push File.expand_path('../lib', __FILE__)
+
 Gem::Specification.new do |s|
-  s.name    = "gemoji"
-  s.version = "1.2.1"
-  s.summary = "Emoji Assets"
-  s.description = "Emoji assets"
+  s.name    = 'gemoji'
+  s.version = '1.2.1'
+  s.summary = 'Emoji Assets'
+  s.description = 'Emoji assets'
 
-  s.authors  = ["GitHub"]
-  s.email    = "support@github.com"
-  s.homepage = "https://github.com/github/gemoji"
+  s.authors  = ['GitHub']
+  s.email    = 'support@github.com'
+  s.homepage = 'https://github.com/github/gemoji'
 
-  s.files = Dir["README.md", "images/**/*.png", "lib/**/*.rb", "lib/tasks/*.rake"]
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.require_paths = ['lib']
 end

--- a/lib/emoji.rb
+++ b/lib/emoji.rb
@@ -1,15 +1,18 @@
+require 'emoji/railtie' if defined?(::Rails)
+
 module Emoji
-  PATH = File.expand_path("..", __FILE__)
+  PATH = File.expand_path('..', __FILE__)
 
   def self.path
     PATH
   end
 
   def self.images_path
-    File.expand_path("../../images", __FILE__)
+    File.expand_path('../../images', __FILE__)
   end
 
   def self.names
     @names ||= Dir["#{images_path}/emoji/*.png"].sort.map { |fn| File.basename(fn, '.png') }
   end
 end
+

--- a/lib/emoji/railtie.rb
+++ b/lib/emoji/railtie.rb
@@ -1,13 +1,14 @@
 require 'emoji'
-require 'rails'
 
 module Emoji
-  class Engine < Rails::Engine
+  class Railtie < ::Rails::Railtie
+    railtie_name :emoji
+
     rake_tasks do
-      load "tasks/emoji.rake"
+      load 'tasks/emoji.rake'
     end
 
-    initializer :emoji, :group => :assets do |app|
+    initializer 'emoji.initialize' do |app|
       app.config.assets.paths << Emoji.images_path
     end
   end


### PR DESCRIPTION
- Coverts the Rails Engine to a Railtie (since it should be a Railtie)
- Removes the `:asset` group in #15, as it's a breaking change. Assets are not appended to the path.
- Adds `lib` to the load_path.
- Standardized gemspec.
- Use built-in bundler gem tasks.
- Coverts double to single quotes because I have OCD.
- Remove `require` from Gemfile - it's done automatically.
- Update README to use `image_tag`
