### PR TITLE
Identify a source code license in the gemspec

### DIFF
--- a/gemoji.gemspec
+++ b/gemoji.gemspec
@@ -1,5 +1,6 @@
 Gem::Specification.new do |s|
   s.name    = "gemoji"
+  s.license = "MIT"
   s.version = "1.3.0"
   s.summary = "Emoji Assets"
   s.description = "Emoji assets"


### PR DESCRIPTION
This is a stab at identifying a source code license in the gemspec file.  There is currently a LICENSE file in the repository, but it does not identify the license which pertains to the source, itself - rather it only covers the image licenses.

I've taken a guess as identifying this library as using the MIT license.  If that is not the case, then this Pull Request is invalid.  But, please identify some known license, if MIT is not the case.  This library currently carries no source code license that I can see.
