### PR TITLE
Add symlink from :gay: to :rainbow:'s image.

### DIFF
--- a/images/emoji/gay.png
+++ b/images/emoji/gay.png
@@ -1,0 +1,1 @@
+unicode/1f308.png


### PR DESCRIPTION
After a brief discussion in the [CodingSoundtrack](http://codingsoundtrack.org) chat, I decided to implement `:gay:` as `:rainbow:` in the emoji library.  I chose GitHub's implementation as the single most prominent and easy-to-contribute-to implementation.
