### PR TITLE
Fix visual glitch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ config.assets.precompile << "emoji/*.png"
 Example Rails Helper
 --------------------
 
-This would allow emojifying content such as: `it's raining :cat:s and :dog:s!`
+This would allow emojifying content such as: "it's raining :cat:s and :dog:s!"
 
 See the [Emoji cheat sheet](http://www.emoji-cheat-sheet.com) for more examples.
 


### PR DESCRIPTION
I noticed this glitch when looking at the homepage for your repo. I have verified that this change actually displays as intended.
