### PR TITLE
Symlink aubergine to eggplant

### DIFF
--- a/images/emoji/aubergine.png
+++ b/images/emoji/aubergine.png
@@ -1,0 +1,1 @@
+unicode/1f346.png


### PR DESCRIPTION
Hello! In the United Kingdom, an eggplant is called an [aubergine](http://en.wikipedia.org/wiki/Aubergine) :eggplant:.

We very much enjoy putting aubergines all over our GitHub repositories and would like to use the correct word for them.

:heart: 
