### PR TITLE
:fire: old gemoji API

### DIFF
--- a/lib/emoji.rb
+++ b/lib/emoji.rb
@@ -34,35 +34,6 @@ module Emoji
     }
   end
 
-  def names
-    @names ||= names_index.keys.sort
-  end
-
-  def unicodes
-    @unicodes ||= unicodes_index.keys
-  end
-
-  def custom
-    @custom ||= all.map { |emoji|
-      emoji.aliases if emoji.custom?
-    }.compact.flatten.sort
-  end
-
-  def unicode_for(name)
-    emoji = find_by_alias(name) { return nil }
-    emoji.raw
-  end
-
-  def name_for(unicode)
-    emoji = find_by_unicode(unicode) { return nil }
-    emoji.name
-  end
-
-  def names_for(unicode)
-    emoji = find_by_unicode(unicode) { return nil }
-    emoji.aliases
-  end
-
   private
     def create_index
       index = Hash.new { |hash, key| hash[key] = [] }

--- a/test/emoji_test.rb
+++ b/test/emoji_test.rb
@@ -6,14 +6,9 @@ class EmojiTest < TestCase
     assert count > 845, "there were too few emojis: #{count}"
   end
 
-  test "names array contains the names" do
-    count = Emoji.names.size
-    assert count > 845, "there were too few emoji names: #{count}"
-  end
-
-  test "unicodes array contains the unicodes" do
+  test "unicodes set contains the unicodes" do
     min_size = Emoji.all.reject(&:custom?).size
-    count = Emoji.unicodes.size
+    count = Emoji.all.map(&:unicode_aliases).flatten.size
     assert count > min_size, "there were too few unicode mappings: #{count}"
   end
 
@@ -68,57 +63,25 @@ class EmojiTest < TestCase
     assert emoji.tags.include?('pleased')
   end
 
-  Emoji.names.each do |name|
-    test "#{name} is a valid name" do
-      assert_match /^[\w\+\-]+$/, name
+  test "emojis have valid names" do
+    Emoji.all.each do |emoji|
+      assert_match /^[\w\+\-]+$/, emoji.name
     end
   end
 
-  test "custom array contains the non-Apple emoji" do
-    assert Emoji.custom.include?("shipit")
-    assert !Emoji.custom.include?("+1")
-  end
+  test "custom emojis" do
+    custom = Emoji.all.select(&:custom?)
+    assert custom.size > 0
 
-  test "unicode for" do
-    assert_equal "\u{1f6af}", Emoji.unicode_for("do_not_litter")
-    assert_equal "\u{1f1e8}\u{1f1f3}", Emoji.unicode_for("cn")
-    assert_equal nil, Emoji.unicode_for("$$$$$")
-    assert_equal nil, Emoji.unicode_for(nil)
-  end
-
-  (Emoji.names - Emoji.custom).each do |name|
-    test "unicode for #{name}" do
-      assert !Emoji.unicode_for(name).nil?
+    custom.each do |emoji|
+      assert_nil emoji.raw
+      assert_equal [], emoji.unicode_aliases
     end
   end
 
-  Emoji.custom.each do |name|
-    test "no unicode for #{name}" do
-      assert Emoji.unicode_for(name).nil?
-    end
-  end
-
-  test "name for" do
-    assert_equal "do_not_litter", Emoji.name_for("\u{1f6af}")
-    assert_equal "cn", Emoji.name_for("\u{1f1e8}\u{1f1f3}")
-    assert_equal nil, Emoji.name_for("$$$$$")
-    assert_equal nil, Emoji.name_for(nil)
-  end
-
-  test "names_for" do
-    assert_equal %w[hocho knife], Emoji.names_for("\u{1f52a}")
-    assert_equal nil, Emoji.names_for("$$$$$")
-  end
-
-  Emoji.unicodes.each do |unicode|
-    test "name for #{unicode}" do
-      assert !Emoji.name_for(unicode).nil?
-    end
-  end
-
-  test "support for unicode variation selectors" do
-    assert_equal "heart", Emoji.name_for("\u{2764}")
-    assert_equal "heart", Emoji.name_for("\u{2764}\u{fe0f}")
-    assert_equal "\u{2764}\u{fe0f}", Emoji.unicode_for("heart")
+  test "custom emoji names" do
+    custom_names = Emoji.all.select(&:custom?).map(&:name)
+    assert custom_names.include?("shipit")
+    assert !custom_names.include?("+1")
   end
 end


### PR DESCRIPTION
Nukes:
- `Emoji.names`
- `Emoji.unicodes`
- `Emoji.custom`
- `Emoji.name_for`
- `Emoji.unicode_for`

in favor of:
- `Emoji.all`
- `Emoji.find_by_alias`
- `Emoji.find_by_unicode`

/cc @josh @aroben
