### PR TITLE
Change find_by_* to return nil rather than raise an exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See the [Emoji cheat sheet](http://www.emoji-cheat-sheet.com) for more examples.
 module EmojiHelper
   def emojify(content)
     h(content).to_str.gsub(/:([\w+-]+):/) do |match|
-      if emoji = Emoji.find_by_alias($1) { nil }
+      if emoji = Emoji.find_by_alias($1)
         %(<img alt="#$1" src="#{asset_path("emoji/#{emoji.image_filename}")}" style="vertical-align:middle" width="20" height="20" />)
       else
         match

--- a/lib/emoji.rb
+++ b/lib/emoji.rb
@@ -47,23 +47,34 @@ module Emoji
     emoji
   end
 
+  # Public: Find an emoji by its aliased name. Return nil if missing.
   def find_by_alias(name)
-    names_index.fetch(name) {
-      if block_given? then yield name
-      else raise NotFound, "Emoji not found by name: %s" % name.inspect
-      end
-    }
+    fetch_by_alias name, nil
   end
 
+  # Public: Find an emoji by its unicode character. Return nil if missing.
   def find_by_unicode(unicode)
-    unicodes_index.fetch(unicode) {
-      if block_given? then yield unicode
-      else raise NotFound, "Emoji not found from unicode: %s" % Emoji::Character.hex_inspect(unicode)
-      end
-    }
+    fetch_by_unicode unicode, nil
+  end
+
+  # Public: Fetch an emoji by its aliased name. If missing, return the default
+  # value if provided, call the default block if provided, or raise NotFound.
+  def fetch_by_alias(name, *default_value, &default_block)
+    default_block ||= MISSING_ALIAS if default_value.empty?
+    names_index.fetch name, *default_value, &default_block
+  end
+
+  # Public: Fetch an emoji by its Unicode character. If missing, return the
+  # default value if provided, call the default block if provided, or raise
+  # NotFound.
+  def fetch_by_unicode(unicode, *default_value, &default_block)
+    default_block ||= MISSING_UNICODE if default_value.empty?
+    unicodes_index.fetch unicode, *default_value, &default_block
   end
 
   private
+    MISSING_ALIAS = lambda { |name| raise NotFound, "Emoji not found by name: %s" % name.inspect }
+    MISSING_UNICODE = lambda { |unicode| raise NotFound, "Emoji not found from unicode: %s" % Emoji::Character.hex_inspect(unicode) }
     VARIATION_SELECTOR_16 = "\u{fe0f}".freeze
 
     def parse_data_file

--- a/test/emoji_test.rb
+++ b/test/emoji_test.rb
@@ -12,37 +12,61 @@ class EmojiTest < TestCase
     assert count > min_size, "there were too few unicode mappings: #{count}"
   end
 
+  test "finding emoji by alias" do
+    refute_nil Emoji.find_by_alias('smile')
+  end
+
+  test "finding nonexistent emoji by alias returns nil" do
+    assert_nil Emoji.find_by_alias('$$$')
+  end
+
+  test "finding emoji by unicode" do
+    refute_nil Emoji.find_by_unicode("\u{1f604}")
+  end
+
+  test "finding nonexistent emoji by unicode returns nil" do
+    assert_nil Emoji.find_by_unicode("\u{1234}")
+  end
+
   test "fetching emoji by alias" do
-    emoji = Emoji.find_by_alias('smile')
+    emoji = Emoji.fetch_by_alias('smile')
     assert_equal "\u{1f604}", emoji.raw
   end
 
-  test "emoji alias not found" do
+  test "fetching nonexistent emoji by alias raises NotFound if neither default value nor block is given" do
     error = assert_raises Emoji::NotFound do
-      Emoji.find_by_alias('$$$')
+      Emoji.fetch_by_alias('$$$')
     end
     assert_equal %(Emoji not found by name: "$$$"), error.message
   end
 
-  test "emoji by alias fallback block" do
-    emoji = Emoji.find_by_alias('hello') { |name| name.upcase }
+  test "fetching nonexistent emoji by alias returns default value" do
+    assert_equal 'default', Emoji.fetch_by_alias('hello', 'default')
+  end
+
+  test "fetching nonexistent emoji by alias returns result of default block" do
+    emoji = Emoji.fetch_by_alias('hello', &:upcase)
     assert_equal 'HELLO', emoji
   end
 
   test "fetching emoji by unicode" do
-    emoji = Emoji.find_by_unicode("\u{1f604}")
+    emoji = Emoji.fetch_by_unicode("\u{1f604}")
     assert_equal 'smile', emoji.name
   end
 
-  test "emoji unicode not found" do
+  test "fetching nonexistent emoji unicode raises NotFound if neither default value nor block is given" do
     error = assert_raises Emoji::NotFound do
-      Emoji.find_by_unicode("\u{1234}\u{abcd}")
+      Emoji.fetch_by_unicode("\u{1234}\u{abcd}")
     end
     assert_equal %(Emoji not found from unicode: 1234-abcd), error.message
   end
 
-  test "emoji by unicode fallback block" do
-    emoji = Emoji.find_by_unicode("\u{1234}") { |u| "not-#{u}-found" }
+  test "fetching nonexistent emoji by unicode returns default value" do
+    assert_equal 'default', Emoji.fetch_by_unicode("\u{1234}", 'default')
+  end
+
+  test "fetching nonexistent emoji by unicode returns result of default block" do
+    emoji = Emoji.fetch_by_unicode("\u{1234}") { |u| "not-#{u}-found" }
     assert_equal "not-\u{1234}-found", emoji
   end
 


### PR DESCRIPTION
This is a breaking API change.
- Rename 2.0.0 find_by_\* to fetch_by_*.
- Introduce find_by_\* which calls fetch_by_\* with a nil default value.
- fetch_by_\* now accepts a default value as well as a default block.

You probably have code that looks like

``` ruby
  if emoji = Emoji.find_by_alias($1) { nil }
```

that you can change to

``` ruby
  if emoji = Emoji.find_by_alias($1)
```

If you expect an exception for missing emoji, switch to

``` ruby
  emoji = Emoji.fetch_by_alias($1)
```

instead.
