### PR TITLE
Change find_by_* to return nil rather than raise an exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See the [Emoji cheat sheet](http://www.emoji-cheat-sheet.com) for more examples.
 module EmojiHelper
   def emojify(content)
     h(content).to_str.gsub(/:([\w+-]+):/) do |match|
-      if emoji = Emoji.find_by_alias($1) { nil }
+      if emoji = Emoji.find_by_alias($1)
         %(<img alt="#$1" src="#{asset_path("emoji/#{emoji.image_filename}")}" style="vertical-align:middle" width="20" height="20" />)
       else
         match

--- a/lib/emoji.rb
+++ b/lib/emoji.rb
@@ -4,8 +4,6 @@ require 'json'
 module Emoji
   extend self
 
-  NotFound = Class.new(IndexError)
-
   def data_file
     File.expand_path('../../db/emoji.json', __FILE__)
   end
@@ -47,20 +45,14 @@ module Emoji
     emoji
   end
 
+  # Public: Find an emoji by its aliased name. Return nil if missing.
   def find_by_alias(name)
-    names_index.fetch(name) {
-      if block_given? then yield name
-      else raise NotFound, "Emoji not found by name: %s" % name.inspect
-      end
-    }
+    names_index[name]
   end
 
+  # Public: Find an emoji by its unicode character. Return nil if missing.
   def find_by_unicode(unicode)
-    unicodes_index.fetch(unicode) {
-      if block_given? then yield unicode
-      else raise NotFound, "Emoji not found from unicode: %s" % Emoji::Character.hex_inspect(unicode)
-      end
-    }
+    unicodes_index[unicode]
   end
 
   private

--- a/test/emoji_test.rb
+++ b/test/emoji_test.rb
@@ -12,38 +12,20 @@ class EmojiTest < TestCase
     assert count > min_size, "there were too few unicode mappings: #{count}"
   end
 
-  test "fetching emoji by alias" do
-    emoji = Emoji.find_by_alias('smile')
-    assert_equal "\u{1f604}", emoji.raw
+  test "finding emoji by alias" do
+    assert_equal 'smile', Emoji.find_by_alias('smile').name
   end
 
-  test "emoji alias not found" do
-    error = assert_raises Emoji::NotFound do
-      Emoji.find_by_alias('$$$')
-    end
-    assert_equal %(Emoji not found by name: "$$$"), error.message
+  test "finding nonexistent emoji by alias returns nil" do
+    assert_nil Emoji.find_by_alias('$$$')
   end
 
-  test "emoji by alias fallback block" do
-    emoji = Emoji.find_by_alias('hello') { |name| name.upcase }
-    assert_equal 'HELLO', emoji
+  test "finding emoji by unicode" do
+    assert_equal "\u{1f604}", Emoji.find_by_unicode("\u{1f604}").raw
   end
 
-  test "fetching emoji by unicode" do
-    emoji = Emoji.find_by_unicode("\u{1f604}")
-    assert_equal 'smile', emoji.name
-  end
-
-  test "emoji unicode not found" do
-    error = assert_raises Emoji::NotFound do
-      Emoji.find_by_unicode("\u{1234}\u{abcd}")
-    end
-    assert_equal %(Emoji not found from unicode: 1234-abcd), error.message
-  end
-
-  test "emoji by unicode fallback block" do
-    emoji = Emoji.find_by_unicode("\u{1234}") { |u| "not-#{u}-found" }
-    assert_equal "not-\u{1234}-found", emoji
+  test "finding nonexistent emoji by unicode returns nil" do
+    assert_nil Emoji.find_by_unicode("\u{1234}")
   end
 
   test "unicode_aliases" do


### PR DESCRIPTION
This is a breaking API change. Simpler alternative to #53.

You probably have code that looks like

``` ruby
  if emoji = Emoji.find_by_alias($1) { nil }
```

that you can change to

``` ruby
  if emoji = Emoji.find_by_alias($1)
```
