### PR TITLE
Remove unicode aliases for Kanji emoji

### DIFF
--- a/db/emoji.json
+++ b/db/emoji.json
@@ -6697,9 +6697,6 @@
   }
 , {
     "emoji": "🈯️"
-  , "unicodes": [
-      "指"
-    ]
   , "description": "squared cjk unified ideograph-6307"
   , "aliases": [
       "u6307"
@@ -6709,9 +6706,6 @@
   }
 , {
     "emoji": "🈳"
-  , "unicodes": [
-      "空"
-    ]
   , "description": "squared cjk unified ideograph-7a7a"
   , "aliases": [
       "u7a7a"
@@ -6721,9 +6715,6 @@
   }
 , {
     "emoji": "🈵"
-  , "unicodes": [
-      "満"
-    ]
   , "description": "squared cjk unified ideograph-6e80"
   , "aliases": [
       "u6e80"
@@ -6733,9 +6724,6 @@
   }
 , {
     "emoji": "🈴"
-  , "unicodes": [
-      "合"
-    ]
   , "description": "squared cjk unified ideograph-5408"
   , "aliases": [
       "u5408"
@@ -6745,9 +6733,6 @@
   }
 , {
     "emoji": "🈲"
-  , "unicodes": [
-      "禁"
-    ]
   , "description": "squared cjk unified ideograph-7981"
   , "aliases": [
       "u7981"
@@ -6766,9 +6751,6 @@
   }
 , {
     "emoji": "🈹"
-  , "unicodes": [
-      "割"
-    ]
   , "description": "squared cjk unified ideograph-5272"
   , "aliases": [
       "u5272"
@@ -6778,9 +6760,6 @@
   }
 , {
     "emoji": "🈺"
-  , "unicodes": [
-      "営"
-    ]
   , "description": "squared cjk unified ideograph-55b6"
   , "aliases": [
       "u55b6"
@@ -6790,9 +6769,6 @@
   }
 , {
     "emoji": "🈶"
-  , "unicodes": [
-      "有"
-    ]
   , "description": "squared cjk unified ideograph-6709"
   , "aliases": [
       "u6709"
@@ -6802,9 +6778,6 @@
   }
 , {
     "emoji": "🈚️"
-  , "unicodes": [
-      "無"
-    ]
   , "description": "squared cjk unified ideograph-7121"
   , "aliases": [
       "u7121"
@@ -6908,9 +6881,6 @@
   }
 , {
     "emoji": "🈷"
-  , "unicodes": [
-      "月"
-    ]
   , "description": "squared cjk unified ideograph-6708"
   , "aliases": [
       "u6708"
@@ -6920,9 +6890,6 @@
   }
 , {
     "emoji": "🈸"
-  , "unicodes": [
-      "申"
-    ]
   , "description": "squared cjk unified ideograph-7533"
   , "aliases": [
       "u7533"

--- a/test/emoji_test.rb
+++ b/test/emoji_test.rb
@@ -28,9 +28,9 @@ class EmojiTest < TestCase
     assert_nil Emoji.find_by_unicode("\u{1234}")
   end
 
-  test "unicode_aliases" do
+  test "unicode_aliases don't include Kanji raw form" do
     emoji = Emoji.find_by_unicode("\u{1f237}")
-    assert_equal ["\u{1f237}", "\u{6708}"], emoji.unicode_aliases
+    assert_equal ["\u{1f237}"], emoji.unicode_aliases
   end
 
   test "unicode_aliases includes form without variation selector" do


### PR DESCRIPTION
If we use unicode_aliases to do a search & replace in text turning raw emoji characters into markup, these aliases will corrupt regular Japanese text.

/cc @aroben
