### PR TITLE
Fix bug in example helper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ See the [Emoji cheat sheet](http://www.emoji-cheat-sheet.com) for more examples.
 module EmojiHelper
   def emojify(content)
     h(content).to_str.gsub(/:([\w+-]+):/) do |match|
-      if emoji = Emoji.find_by_alias($1)
+      begin
+        emoji = Emoji.find_by_alias($1)
         %(<img alt="#$1" src="#{asset_path("emoji/#{emoji.image_filename}")}" style="vertical-align:middle" width="20" height="20" />)
-      else
+      rescue
         match
       end
     end.html_safe if content.present?


### PR DESCRIPTION
`Emoji::find_by_alias` will actually raise an exception rather than return falsy when the alias is not found. Hence, `begin...rescue...end` should be used instead of `if...else....end`.
