### PR TITLE
Add support for non-PNG assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ emoji.image_filename #=> "music.png"
 As you create new emoji, you must ensure that you also create and put the images
 they reference by their `image_filename` to your assets directory.
 
+You can customize `image_filename` with:
+
+```ruby
+emoji = Emoji.create("music") do |char|
+  char.image_filename = "subdirectory/my_emoji.gif"
+end
+```
+
 For existing emojis, you can edit the list of aliases or add new tags in an edit block:
 
 ```ruby

--- a/lib/emoji/character.rb
+++ b/lib/emoji/character.rb
@@ -51,7 +51,19 @@ module Emoji
       self.class.hex_inspect(raw)
     end
 
+    attr_writer :image_filename
+
     def image_filename
+      if defined? @image_filename
+        @image_filename
+      else
+        default_image_filename
+      end
+    end
+
+    private
+
+    def default_image_filename
       if custom?
         '%s.png' % name
       else

--- a/test/emoji_test.rb
+++ b/test/emoji_test.rb
@@ -94,6 +94,18 @@ class EmojiTest < TestCase
     end
   end
 
+  test "create with custom filename" do
+    emoji = Emoji.create("music") do |char|
+      char.image_filename = "some_path/my_emoji.gif"
+    end
+
+    begin
+      assert_equal "some_path/my_emoji.gif", emoji.image_filename
+    ensure
+      Emoji.all.pop
+    end
+  end
+
   test "create without block" do
     emoji = Emoji.create("music")
 


### PR DESCRIPTION
This adds support for having custom emojis that aren't PNG files. In other words - you can now have animated GIFs.

Usage:

``` ruby
emoji = Emoji.create("music") do |char|
  char.set_format "gif"
end

emoji.image_filename # => "music.gif"
```
