### PR TITLE
Use image_path instead of asset_path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ module EmojiHelper
   def emojify(content)
     h(content).to_str.gsub(/:([\w+-]+):/) do |match|
       if emoji = Emoji.find_by_alias($1)
-        %(<img alt="#$1" src="#{asset_path("emoji/#{emoji.image_filename}")}" style="vertical-align:middle" width="20" height="20" />)
+        %(<img alt="#$1" src="#{image_path("emoji/#{emoji.image_filename}")}" style="vertical-align:middle" width="20" height="20" />)
       else
         match
       end

--- a/test/documentation_test.rb
+++ b/test/documentation_test.rb
@@ -18,7 +18,7 @@ class DocumentationTest < TestCase
       str.gsub('<', '&lt;').gsub('>', '&gt;')
     end
 
-    def self.asset_path(img)
+    def self.image_path(img)
       "/images/#{img}?123"
     end
   end


### PR DESCRIPTION
In Rails 4.2 using `asset_path` doesn't work properly, because `asset_path` I think doesn't do anything except detect cache URLs. With `image_path` it works for me.