### PR TITLE
Add code of conduct to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,6 @@
+This project adheres to the [Open Code of Conduct][code-of-conduct]. By participating, you are expected to uphold this code.
+[code-of-conduct]: http://todogroup.org/opencodeofconduct/#gemoji/opensource@github.com
+
 Our emoji set is based off Apple's emoji character palette, plus some custom
 emoji such as :octocat: :shipit: :metal:.
 


### PR DESCRIPTION
We are intending to adopt the soon-to-be-announced [Open Code of Conduct](http://todogroup.org/opencodeofconduct) for all @github projects. This adds it to the contributing guidelines. Let me know if you have any questions or concerns.