### PR TITLE
Escape mkdir paths for rake emoji task

### DIFF
--- a/lib/tasks/emoji.rake
+++ b/lib/tasks/emoji.rake
@@ -3,5 +3,5 @@ task :emoji do
   require 'emoji'
 
   target = "#{Rake.original_dir}/public/images"
-  `mkdir -p #{target} && cp -Rp #{Emoji.images_path}/emoji #{target}`
+  `mkdir -p '#{target}' && cp -Rp '#{Emoji.images_path}/emoji' '#{target}'`
 end


### PR DESCRIPTION
In the event that someone tries to copy the gemoji emoji's into their
project using the rake emoji task, if that person has braces ( or ) in
the path, the task will fail. Example of error:

```
sh: -c: line 0: syntax error near unexpected token `('
sh: -c: line 0: `mkdir -p /Users/gmiller/Dropbox (Personal)/projects/gavinmiller.io/public/images && 
  cp -Rp /Users/gmiller/.rbenv/versions/2.0.0-p598/lib/ruby/gems/2.0.0/gems/gemoji-2.1.0/images/emoji
  /Users/gmiller/Dropbox (Personal)/projects/gavinmiller.io/public/images'
```

By escaping the paths in the rake task, this problem no longer occurs.