### PR TITLE
Using guard clause in example rails_helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,14 @@ See the [Emoji cheat sheet](http://www.emoji-cheat-sheet.com) for more examples.
 ```ruby
 module EmojiHelper
   def emojify(content)
+    return "" unless content.present?
     h(content).to_str.gsub(/:([\w+-]+):/) do |match|
       if emoji = Emoji.find_by_alias($1)
         %(<img alt="#$1" src="#{image_path("emoji/#{emoji.image_filename}")}" style="vertical-align:middle" width="20" height="20" />)
       else
         match
       end
-    end.html_safe if content.present?
+    end.html_safe
   end
 end
 ```

--- a/test/documentation_test.rb
+++ b/test/documentation_test.rb
@@ -41,6 +41,6 @@ class DocumentationTest < TestCase
   end
 
   test "returns nil for blank content" do
-    assert_nil Helper.emojify('')
+    assert "", Helper.emojify('')
   end
 end


### PR DESCRIPTION
Using guard clause in example rails helper to return empty string instead of nil.
This approach prevents code crashes in the further content processing.