### PR TITLE
consistency with :ok_woman:

### DIFF
--- a/db/emoji.json
+++ b/db/emoji.json
@@ -1382,6 +1382,7 @@
   , "description": "face with no good gesture"
   , "aliases": [
       "no_good"
+    , "ng_woman"
     ]
   , "tags": [
       "stop"


### PR DESCRIPTION
`:ok_woman:` - :ok_woman: 
`:no_good:` - :no_good: 
`:ng:` - :ng:

`:ok_woman:` is notable, because it's an OK circle being performed by a woman.
`:no_good:` is not, especially considering the other possibilities :no_entry_sign:, :ng:

There is an awkward collision with :no_good: (`:no_good:`) and :ng: (`:ng:`), and a glaring lack of consistency between :ok_woman: and :no_good:.

Without going in and changing well entrenched ASCII equivalents, the easiest solution here is to add an alias so that `:ng_woman:` works for :no_good:.