### PR TITLE
emojify unicode content

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ config.assets.precompile << "emoji/**/*.png"
 Example Rails Helper
 --------------------
 
-This would allow emojifying content such as: `it's raining :cat:s and :dog:s!`
+This would allow emojifying content such as: `it's raining :cat:s and :dog:s!` or emojifying unicode content such as `it's raining 🐱s and 🐶s!`
 
 See the [Emoji cheat sheet](http://www.emoji-cheat-sheet.com) for more examples.
 
@@ -58,6 +58,16 @@ module EmojiHelper
     h(content).to_str.gsub(/:([\w+-]+):/) do |match|
       if emoji = Emoji.find_by_alias($1)
         %(<img alt="#$1" src="#{image_path("emoji/#{emoji.image_filename}")}" style="vertical-align:middle" width="20" height="20" />)
+      else
+        match
+      end
+    end.html_safe if content.present?
+  end
+
+  def emojify_unicodes(content)
+    h(content).to_str.gsub(Emoji.unicodes_regex) do |match|
+      if emoji = Emoji.find_by_unicode(match)
+        %(<img alt="#{match}" src="#{image_path("emoji/#{emoji.image_filename}")}" style="vertical-align:middle" width="20" height="20" />)
       else
         match
       end

--- a/lib/emoji.rb
+++ b/lib/emoji.rb
@@ -55,6 +55,13 @@ module Emoji
     unicodes_index[unicode]
   end
 
+  def unicodes_regex
+    all unless defined? @all
+    #.sort.reverse in order to match '1f44d-1f3ff' before '1f44d'
+    #'*' is escaped (in emojione collection set 2016)
+    @unicodes_regex ||= /#{@unicodes_index.keys.sort.reverse.join('|').gsub('*','\*')}/
+  end
+
   private
     VARIATION_SELECTOR_16 = "\u{fe0f}".freeze
 

--- a/test/documentation_test.rb
+++ b/test/documentation_test.rb
@@ -43,4 +43,26 @@ class DocumentationTest < TestCase
   test "returns nil for blank content" do
     assert_nil Helper.emojify('')
   end
+
+  test "replaces emoji unicodes with images" do
+    assert_equal "It's raining " \
+        '<img alt="🐱" src="/images/emoji/unicode/1f431.png?123" style="vertical-align:middle" width="20" height="20" />s and ' \
+        '<img alt="🐶" src="/images/emoji/unicode/1f436.png?123" style="vertical-align:middle" width="20" height="20" />s!',
+      Helper.emojify_unicodes("It's raining 🐱s and 🐶s!")
+  end
+
+  test "doesn't replace unknown emoji" do
+    content = "\u{12345}is in \u{1111}"
+    assert_equal content, Helper.emojify_unicodes(content)
+  end
+
+  test "escapes other HTML" do
+    assert_equal "You have been &lt;script&gt;alert('pwned!')&lt;/script&gt;",
+      Helper.emojify_unicodes("You have been <script>alert('pwned!')</script>")
+  end
+
+  test "returns nil for blank content" do
+    assert_nil Helper.emojify_unicodes('')
+  end
+
 end


### PR DESCRIPTION
I am storing unicode content instead of short names in my db

I use a long unicodes_regex that is loaded once needed. It is compatible with "composed" emojis like 👨‍👩‍👦‍👦