### PR TITLE
Add a laugh alias and a hooray alias to 😄 and 🎉

### DIFF
--- a/db/emoji.json
+++ b/db/emoji.json
@@ -34,6 +34,7 @@
   , "category": "People"
   , "aliases": [
       "smile"
+    , "laugh"
     ]
   , "tags": [
       "happy"
@@ -10589,6 +10590,7 @@
   , "category": "Objects"
   , "aliases": [
       "tada"
+    , "hooray"
     ]
   , "tags": [
       "party"

--- a/db/emoji.json
+++ b/db/emoji.json
@@ -34,11 +34,11 @@
   , "category": "People"
   , "aliases": [
       "smile"
-    , "laugh"
     ]
   , "tags": [
       "happy"
     , "joy"
+    , "laugh"
     , "pleased"
     ]
   , "unicode_version": "6.0"
@@ -10590,10 +10590,10 @@
   , "category": "Objects"
   , "aliases": [
       "tada"
-    , "hooray"
     ]
   , "tags": [
-      "party"
+      "hooray"
+    , "party"
     ]
   , "unicode_version": "6.0"
   , "ios_version": "6.0"


### PR DESCRIPTION
In the GitHub Reactions menu, there are six emoji: 👍, 👎, 😄, 🎉, 😕, and ❤️. However, two out of the six (😄 and 🎉) have descriptions (“Laugh” and “Hooray”) that do not actually correspond to Gemoji aliases. Add new aliases to those two Gemoji so that they directly correspond to the GitHub Reactions.

In other words, 😄 [is called “Laugh”](https://cloud.githubusercontent.com/assets/17259768/22864081/589fa5ac-f0ff-11e6-85bb-d36c2cdf66a4.png) and 🎉 [is called ”Hooray“](https://cloud.githubusercontent.com/assets/17259768/22864095/ab980cc2-f0ff-11e6-9e06-060ba08a822f.png), but `:laugh:` and `:hooray:` don’t exist. Add them.
