### PR TITLE
Add "sassy" alias to information desk people

### DIFF
--- a/db/emoji.json
+++ b/db/emoji.json
@@ -2656,6 +2656,7 @@
   , "aliases": [
       "tipping_hand_woman"
     , "information_desk_person"
+    , "sassy_woman"
     ]
   , "tags": [
     ]
@@ -2668,6 +2669,7 @@
   , "category": "People"
   , "aliases": [
       "tipping_hand_man"
+    , "sassy_man"
     ]
   , "tags": [
       "information"


### PR DESCRIPTION
💁 is widely accepted as indicating *sass* or *sarcasm*.

> An information desk person, iconically represented in the Apple emoji artwork as a girl holding out her hand as if she were a waitress carrying an invisible tray of drinks.
> Can be used for a variety of interpretations, such as sassiness or sarcasm.
> Person Tipping Hand was approved as part of Unicode 6.0 in 2010 under the name “Information Desk Person” and added to Emoji 1.0 in 2015.

http://emojipedia.org/information-desk-person/

##

CC: @muan @notwaldorf