### PR TITLE
Freeze string literals when using a modern Ruby

### DIFF
--- a/lib/emoji.rb
+++ b/lib/emoji.rb
@@ -1,4 +1,6 @@
 # encoding: utf-8
+# frozen_string_literal: true
+
 require 'emoji/character'
 require 'json'
 

--- a/lib/emoji/character.rb
+++ b/lib/emoji/character.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Emoji
   class Character
     # Inspect individual Unicode characters in a string by dumping its

--- a/lib/emoji/cli.rb
+++ b/lib/emoji/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'emoji/extractor'
 require 'fileutils'
 require 'optparse'

--- a/lib/emoji/extractor.rb
+++ b/lib/emoji/extractor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'emoji'
 require 'fileutils'
 

--- a/lib/gemoji.rb
+++ b/lib/gemoji.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'emoji'


### PR DESCRIPTION
Reduce string allocations on Ruby versions >= 2.3.0 by freezing string literals