### PR TITLE
Compute static paths once per method call

### DIFF
--- a/lib/emoji.rb
+++ b/lib/emoji.rb
@@ -6,15 +6,15 @@ module Emoji
   extend self
 
   def data_file
-    File.expand_path('../../db/emoji.json', __FILE__)
+    @data_file ||= File.expand_path('../../db/emoji.json', __FILE__)
   end
 
   def apple_palette_file
-    File.expand_path('../../db/Category-Emoji.json', __FILE__)
+    @apple_palette_file ||= File.expand_path('../../db/Category-Emoji.json', __FILE__)
   end
 
   def images_path
-    File.expand_path("../../images", __FILE__)
+   @images_path ||= File.expand_path("../../images", __FILE__)
   end
 
   def all


### PR DESCRIPTION
Ideally, these should either be just constants or public methods to private constants, but I'm memoizing them for now. The rationale for this change can be illustrated by the following:
```ruby
3.times do
  puts File.expand_path('../../db/emoji.json', __FILE__).object_id
end

# 40019380
# 40019200
# 40019100
```
