### PR TITLE
Interpolate gender-variation regex just once

### DIFF
--- a/lib/emoji.rb
+++ b/lib/emoji.rb
@@ -102,7 +102,7 @@ module Emoji
       data.each do |raw_emoji|
         raw = raw_emoji['emoji']
         next unless raw
-        no_gender = raw.sub(/(#{VARIATION_SELECTOR_16})?#{ZERO_WIDTH_JOINER}(#{FEMALE_SYMBOL}|#{MALE_SYMBOL})/, '')
+        no_gender = raw.sub(/(#{VARIATION_SELECTOR_16})?#{ZERO_WIDTH_JOINER}(#{FEMALE_SYMBOL}|#{MALE_SYMBOL})/o, '')
         next unless $2
         emoji = find_by_unicode(no_gender)
         next unless emoji


### PR DESCRIPTION
This teeny change provides a HUGE relief from memory allocation.
To confirm, you may use the script below and manually compare with `master` and this PR:
```ruby
# frozen_string_literal: true

require "memory_profiler"
require "bundler/setup"

report = MemoryProfiler.report { require "gemoji" }
report.pretty_print(scale_bytes: true, detailed_report: false)
```
Local tests at my end provides the following:
### Before
```
Total allocated: 7.01 MB (79199 objects)
Total retained:  1.14 MB (21036 objects)
```
### After
```
Total allocated: 3.74 MB (62029 objects)
Total retained:  1.14 MB (21038 objects)
```