### PR TITLE
Fix ArgumentError in emoji-test-parser

### DIFF
--- a/db/emoji-test-parser.rb
+++ b/db/emoji-test-parser.rb
@@ -91,7 +91,7 @@ if $0 == __FILE__
     html_output = true
   end
 
-  _, categories = EmojiTestParser.parse
+  _, categories = EmojiTestParser.parse(File.expand_path("../../vendor/unicode-emoji-test.txt", __FILE__))
 
   trap(:PIPE) { abort }
 


### PR DESCRIPTION
This Pull Request fixes 👇 

```shell
$ ruby db/emoji-test-parser.rb
db/emoji-test-parser.rb:21:in `parse': wrong number of arguments (given 0, expected 1) (ArgumentError)
```

Follow up of e55d145.
