### PR TITLE
Fix db/index.html

### DIFF
--- a/db/index.html
+++ b/db/index.html
@@ -85,7 +85,7 @@ li > span {
       renderEmoji(json)
     }
   }
-  xhr.open('GET', 'emoji.json')
+  xhr.open('GET', 'https://raw.githubusercontent.com/github/gemoji/master/db/emoji.json')
   xhr.send(null)
 
   function searchEmoji(query) {

--- a/db/index.html
+++ b/db/index.html
@@ -85,7 +85,7 @@ li > span {
       renderEmoji(json)
     }
   }
-  xhr.open('GET', 'emoji.json', false)
+  xhr.open('GET', 'emoji.json')
   xhr.send(null)
 
   function searchEmoji(query) {


### PR DESCRIPTION
The `db/index.html` is not loading right now because `XMLHttpRequest` cannot load local `db/emoji.json`. After some googling, it seems not possible to load from a local file.

This Pull Request loads the JSON from https://raw.githubusercontent.com/github/gemoji/master/db/emoji.json. Also fix a deprecation warning.

After this Pull Request, it works again 😀:

<img width="322" alt="スクリーンショット 2019-09-18 01 07 08" src="https://user-images.githubusercontent.com/1000669/65059290-b70c0300-d9b0-11e9-90a8-325e90128177.png">
