### PR TITLE
Safely transliterate international characters for aliases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "rake", "~> 10.3.2"
 gem "minitest", "~> 5.3.5"
+gem "i18n", "~> 1.8.5"
 
 gemspec

--- a/db/dump.rb
+++ b/db/dump.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require "i18n"
 require 'emoji'
 require 'json'
 require_relative './emoji-test-parser'
 
+I18n.config.available_locales = :en
 items = []
 
 _, categories = EmojiTestParser.parse(File.expand_path("../../vendor/unicode-emoji-test.txt", __FILE__))
@@ -34,7 +36,7 @@ for category in categories
         )
       else
         output_item.update(
-          aliases: [description.gsub(/\W+/, '_').downcase],
+          aliases: [I18n.transliterate(description).gsub(/\W+/, '_').downcase],
           tags: [],
           unicode_version: "13.0",
           ios_version: "14.0",


### PR DESCRIPTION
Currently when we encounter an international character (from the perspective of someone in the USA, or UK), we replace it with an underscore (_)

This isn't ideal because it means words like piñata become pi_ata. There's a good way to transliterate these characters into their ASCII character range representation using the i18n library.

This will take the excellent detective work done by @stone-zeng and use that to create a fix.

Relates to: github/gemoji#180
