### PR TITLE
Change envelope and email alias

### DIFF
--- a/db/emoji.json
+++ b/db/emoji.json
@@ -15295,6 +15295,7 @@
     ]
   , "tags": [
       "letter"
+    , "email"
     ]
   , "unicode_version": ""
   , "ios_version": "6.0"

--- a/db/emoji.json
+++ b/db/emoji.json
@@ -15291,7 +15291,7 @@
   , "description": "envelope"
   , "category": "Objects"
   , "aliases": [
-    "envelope"
+      "envelope"
     ]
   , "tags": [
       "letter"

--- a/db/emoji.json
+++ b/db/emoji.json
@@ -15291,8 +15291,7 @@
   , "description": "envelope"
   , "category": "Objects"
   , "aliases": [
-      "email"
-    , "envelope"
+    "envelope"
     ]
   , "tags": [
       "letter"
@@ -15306,6 +15305,7 @@
   , "category": "Objects"
   , "aliases": [
       "e-mail"
+    , "email"
     ]
   , "tags": [
     ]

--- a/db/emoji.json
+++ b/db/emoji.json
@@ -15305,8 +15305,8 @@
   , "description": "e-mail"
   , "category": "Objects"
   , "aliases": [
-      "e-mail"
-    , "email"
+      "email"
+    , "e-mail"
     ]
   , "tags": [
     ]


### PR DESCRIPTION
This changes the alias for ```email``` to no longer be associated with ```envelope```, but with ```e-mail```. For compatibility purposes, ```email``` has been added as a tag on ```envelope```. This implements the change described in #184.