### PR TITLE
Touch up emoji integrity tests

### DIFF
--- a/test/emoji_test.rb
+++ b/test/emoji_test.rb
@@ -56,6 +56,13 @@ class EmojiTest < TestCase
     /^family_/,
   ]
 
+  DASH_EXCEPTIONS = [
+    "-1",
+    "t-rex",
+    "e-mail",
+    "non-potable_water",
+  ]
+
   test "emojis have valid names" do
     aliases = Emoji.all.flat_map(&:aliases)
 
@@ -74,7 +81,7 @@ class EmojiTest < TestCase
     alias_count = Hash.new(0)
     aliases.each do |name|
       alias_count[name] += 1
-      invalid << name if name !~ /\A[\w+-]+\Z/
+      invalid << name if name !~ /\A[\w+]+\Z/ && !DASH_EXCEPTIONS.include?(name)
       another_gender = to_another_gender.call(name)
       gender_mismatch << another_gender unless aliases.include?(another_gender)
     end

--- a/test/emoji_test.rb
+++ b/test/emoji_test.rb
@@ -50,9 +50,8 @@ class EmojiTest < TestCase
   GENDER_EXCEPTIONS = [
     "man_with_gua_pi_mao",
     "woman_with_headscarf",
-    "pregnant_woman",
     "isle_of_man",
-    "blonde_woman",
+    "blonde_woman", # blond_haired_man
     /^couple(kiss)?_/,
     /^family_/,
   ]

--- a/test/emoji_test.rb
+++ b/test/emoji_test.rb
@@ -96,7 +96,6 @@ class EmojiTest < TestCase
   test "missing or incorrect unicodes" do
     emoji_map, _ = EmojiTestParser.parse(File.expand_path("../../vendor/unicode-emoji-test.txt", __FILE__))
     source_unicode_emoji = emoji_map.values
-    supported_sequences = Emoji.all.flat_map(&:unicode_aliases)
     text_glyphs = Emoji.const_get(:TEXT_GLYPHS)
 
     missing = 0


### PR DESCRIPTION
Some minor test improvements. Most notable: new emoji aliases that contain a dash (`-`) character are prohibited.