### PR TITLE
Fix Ruby 2.6 breakage

### DIFF
--- a/lib/emoji/character.rb
+++ b/lib/emoji/character.rb
@@ -51,7 +51,7 @@ module Emoji
       SKIN_TONES.map do |modifier|
         if idx
           # insert modifier before zero-width joiner
-          raw_normalized[...idx] + modifier + raw_normalized[idx..]
+          raw_normalized[0...idx] + modifier + raw_normalized[idx..]
         else
           raw_normalized + modifier
         end

--- a/lib/emoji/character.rb
+++ b/lib/emoji/character.rb
@@ -51,7 +51,7 @@ module Emoji
       SKIN_TONES.map do |modifier|
         if idx
           # insert modifier before zero-width joiner
-          raw_normalized[0...idx] + modifier + raw_normalized[idx..]
+          raw_normalized[0...idx] + modifier + raw_normalized[idx..nil]
         else
           raw_normalized + modifier
         end


### PR DESCRIPTION
Beginless ranges are a [Ruby 2.7](https://ruby-doc.org/core-2.7.0/Range.html#class-Range-label-Beginless-2FEndless+Ranges) feature and should be avoided in this gem which has `required_ruby_version = '> 1.9'`.

(Maybe it would be best to reintroduce Ruby 2.6/older versions in CI as well? Just to avoid unintentional breakage like this. Either that or bump the required ruby version (in a new major version of the gem :slightly_smiling_face:))