### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/github/gemoji/security/code-scanning/2](https://github.com/github/gemoji/security/code-scanning/2)

The ideal fix is to add an explicit `permissions` block to the workflow to restrict the GITHUB_TOKEN to only the minimal necessary permissions required by the workflow. In general, for a typical test job that checks out code and runs tests, only `contents: read` is needed. The fix should be made near the top level of the workflow file, either at the root level (so it applies to all jobs), or specifically under the `test` job if only that job should be restricted. For this workflow file, the recommended way is to add the permissions at the workflow root, directly after the workflow name and before the `on` keyword, to cover all jobs in the workflow. No additional imports or method definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
