### PR TITLE
Import Emoji 17.0 characters

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,5 +20,5 @@ namespace :db do
 end
 
 file 'vendor/unicode-emoji-test.txt' do |t|
-  system 'curl', '-fsSL', 'http://unicode.org/Public/emoji/15.0/emoji-test.txt', '-o', t.name
+  system 'curl', '-fsSL', 'http://unicode.org/Public/17.0.0/emoji/emoji-test.txt', '-o', t.name
 end

--- a/db/dump.rb
+++ b/db/dump.rb
@@ -38,8 +38,8 @@ for category in categories
         output_item.update(
           aliases: [I18n.transliterate(description).gsub(/\W+/, '_').downcase],
           tags: [],
-          unicode_version: "15.0",
-          ios_version: "16.4",
+          unicode_version: "17.0",
+          ios_version: "26.4",
         )
       end
       output_item[:skin_tones] = true if emoji_item[:skin_tones]

--- a/db/emoji.json
+++ b/db/emoji.json
@@ -654,6 +654,30 @@
   , "ios_version": "16.4"
   }
 , {
+    "emoji": "🙂‍↔️"
+  , "description": "head shaking horizontally"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "head_shaking_horizontally"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  }
+, {
+    "emoji": "🙂‍↕️"
+  , "description": "head shaking vertically"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "head_shaking_vertically"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  }
+, {
     "emoji": "😌"
   , "description": "relieved face"
   , "category": "Smileys & Emotion"
@@ -715,6 +739,18 @@
     ]
   , "unicode_version": "6.1"
   , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🫩"
+  , "description": "face with bags under eyes"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "face_with_bags_under_eyes"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "16.0"
+  , "ios_version": "18.4"
   }
 , {
     "emoji": "😷"
@@ -1071,6 +1107,18 @@
     ]
   , "unicode_version": "6.0"
   , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🫪"
+  , "description": "distorted face"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "distorted_face"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "17.0"
+  , "ios_version": "26.4"
   }
 , {
     "emoji": "🥺"
@@ -2018,6 +2066,18 @@
     ]
   , "unicode_version": "6.0"
   , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🫯"
+  , "description": "fight cloud"
+  , "category": "Smileys & Emotion"
+  , "aliases": [
+      "fight_cloud"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "17.0"
+  , "ios_version": "26.4"
   }
 , {
     "emoji": "💥"
@@ -4932,7 +4992,7 @@
   }
 , {
     "emoji": "🧑‍🎄"
-  , "description": "mx claus"
+  , "description": "Mx Claus"
   , "category": "People & Body"
   , "aliases": [
       "mx_claus"
@@ -5304,6 +5364,18 @@
   , "ios_version": "15.4"
   }
 , {
+    "emoji": "🫈"
+  , "description": "hairy creature"
+  , "category": "People & Body"
+  , "aliases": [
+      "hairy_creature"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "17.0"
+  , "ios_version": "26.4"
+  }
+, {
     "emoji": "💆"
   , "description": "person getting massage"
   , "category": "People & Body"
@@ -5425,6 +5497,45 @@
   , "skin_tones": true
   }
 , {
+    "emoji": "🚶‍➡️"
+  , "description": "person walking facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_walking_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🚶‍♀️‍➡️"
+  , "description": "woman walking facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_walking_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🚶‍♂️‍➡️"
+  , "description": "man walking facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_walking_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  , "skin_tones": true
+  }
+, {
     "emoji": "🧍"
   , "description": "person standing"
   , "category": "People & Body"
@@ -5503,6 +5614,45 @@
   , "skin_tones": true
   }
 , {
+    "emoji": "🧎‍➡️"
+  , "description": "person kneeling facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_kneeling_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧎‍♀️‍➡️"
+  , "description": "woman kneeling facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_kneeling_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧎‍♂️‍➡️"
+  , "description": "man kneeling facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_kneeling_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  , "skin_tones": true
+  }
+, {
     "emoji": "🧑‍🦯"
   , "description": "person with white cane"
   , "category": "People & Body"
@@ -5513,6 +5663,19 @@
     ]
   , "unicode_version": "12.1"
   , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🦯‍➡️"
+  , "description": "person with white cane facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_with_white_cane_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
   , "skin_tones": true
   }
 , {
@@ -5529,6 +5692,19 @@
   , "skin_tones": true
   }
 , {
+    "emoji": "👨‍🦯‍➡️"
+  , "description": "man with white cane facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_with_white_cane_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  , "skin_tones": true
+  }
+, {
     "emoji": "👩‍🦯"
   , "description": "woman with white cane"
   , "category": "People & Body"
@@ -5539,6 +5715,19 @@
     ]
   , "unicode_version": "12.0"
   , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🦯‍➡️"
+  , "description": "woman with white cane facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_with_white_cane_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
   , "skin_tones": true
   }
 , {
@@ -5555,6 +5744,19 @@
   , "skin_tones": true
   }
 , {
+    "emoji": "🧑‍🦼‍➡️"
+  , "description": "person in motorized wheelchair facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_in_motorized_wheelchair_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  , "skin_tones": true
+  }
+, {
     "emoji": "👨‍🦼"
   , "description": "man in motorized wheelchair"
   , "category": "People & Body"
@@ -5565,6 +5767,19 @@
     ]
   , "unicode_version": "12.0"
   , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👨‍🦼‍➡️"
+  , "description": "man in motorized wheelchair facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_in_motorized_wheelchair_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
   , "skin_tones": true
   }
 , {
@@ -5581,6 +5796,19 @@
   , "skin_tones": true
   }
 , {
+    "emoji": "👩‍🦼‍➡️"
+  , "description": "woman in motorized wheelchair facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_in_motorized_wheelchair_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  , "skin_tones": true
+  }
+, {
     "emoji": "🧑‍🦽"
   , "description": "person in manual wheelchair"
   , "category": "People & Body"
@@ -5591,6 +5819,19 @@
     ]
   , "unicode_version": "12.1"
   , "ios_version": "13.2"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🦽‍➡️"
+  , "description": "person in manual wheelchair facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_in_manual_wheelchair_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
   , "skin_tones": true
   }
 , {
@@ -5607,6 +5848,19 @@
   , "skin_tones": true
   }
 , {
+    "emoji": "👨‍🦽‍➡️"
+  , "description": "man in manual wheelchair facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_in_manual_wheelchair_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  , "skin_tones": true
+  }
+, {
     "emoji": "👩‍🦽"
   , "description": "woman in manual wheelchair"
   , "category": "People & Body"
@@ -5617,6 +5871,19 @@
     ]
   , "unicode_version": "12.0"
   , "ios_version": "13.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "👩‍🦽‍➡️"
+  , "description": "woman in manual wheelchair facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_in_manual_wheelchair_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
   , "skin_tones": true
   }
 , {
@@ -5666,6 +5933,58 @@
     ]
   , "unicode_version": "6.0"
   , "ios_version": "10.0"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏃‍➡️"
+  , "description": "person running facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "person_running_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏃‍♀️‍➡️"
+  , "description": "woman running facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "woman_running_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🏃‍♂️‍➡️"
+  , "description": "man running facing right"
+  , "category": "People & Body"
+  , "aliases": [
+      "man_running_facing_right"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  , "skin_tones": true
+  }
+, {
+    "emoji": "🧑‍🩰"
+  , "description": "ballet dancer"
+  , "category": "People & Body"
+  , "aliases": [
+      "ballet_dancer"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "17.0"
+  , "ios_version": "26.4"
   , "skin_tones": true
   }
 , {
@@ -5722,6 +6041,7 @@
     ]
   , "unicode_version": "6.0"
   , "ios_version": "6.0"
+  , "skin_tones": true
   }
 , {
     "emoji": "👯‍♂️"
@@ -5735,6 +6055,7 @@
     ]
   , "unicode_version": "6.0"
   , "ios_version": "10.0"
+  , "skin_tones": true
   }
 , {
     "emoji": "👯‍♀️"
@@ -5748,6 +6069,7 @@
     ]
   , "unicode_version": "11.0"
   , "ios_version": "12.1"
+  , "skin_tones": true
   }
 , {
     "emoji": "🧖"
@@ -6254,6 +6576,7 @@
     ]
   , "unicode_version": "11.0"
   , "ios_version": "12.1"
+  , "skin_tones": true
   }
 , {
     "emoji": "🤼‍♂️"
@@ -6266,6 +6589,7 @@
     ]
   , "unicode_version": "9.0"
   , "ios_version": "10.2"
+  , "skin_tones": true
   }
 , {
     "emoji": "🤼‍♀️"
@@ -6278,6 +6602,7 @@
     ]
   , "unicode_version": "9.0"
   , "ios_version": "10.2"
+  , "skin_tones": true
   }
 , {
     "emoji": "🤽"
@@ -6627,21 +6952,6 @@
   , "unicode_version": "6.0"
   , "ios_version": "8.3"
   , "skin_tones": true
-  }
-, {
-    "emoji": "👪"
-  , "description": "family"
-  , "category": "People & Body"
-  , "aliases": [
-      "family"
-    ]
-  , "tags": [
-      "home"
-    , "parents"
-    , "child"
-    ]
-  , "unicode_version": "6.0"
-  , "ios_version": "6.0"
   }
 , {
     "emoji": "👨‍👩‍👦"
@@ -6996,6 +7306,69 @@
   , "ios_version": "14.0"
   }
 , {
+    "emoji": "👪"
+  , "description": "family"
+  , "category": "People & Body"
+  , "aliases": [
+      "family"
+    ]
+  , "tags": [
+      "home"
+    , "parents"
+    , "child"
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🧑‍🧑‍🧒"
+  , "description": "family: adult, adult, child"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_adult_adult_child"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  }
+, {
+    "emoji": "🧑‍🧑‍🧒‍🧒"
+  , "description": "family: adult, adult, child, child"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_adult_adult_child_child"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  }
+, {
+    "emoji": "🧑‍🧒"
+  , "description": "family: adult, child"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_adult_child"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  }
+, {
+    "emoji": "🧑‍🧒‍🧒"
+  , "description": "family: adult, child, child"
+  , "category": "People & Body"
+  , "aliases": [
+      "family_adult_child_child"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  }
+, {
     "emoji": "👣"
   , "description": "footprints"
   , "category": "People & Body"
@@ -7008,6 +7381,18 @@
     ]
   , "unicode_version": "6.0"
   , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🫆"
+  , "description": "fingerprint"
+  , "category": "People & Body"
+  , "aliases": [
+      "fingerprint"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "16.0"
+  , "ios_version": "18.4"
   }
 , {
     "emoji": "🐵"
@@ -8068,6 +8453,18 @@
   , "ios_version": "16.4"
   }
 , {
+    "emoji": "🐦‍🔥"
+  , "description": "phoenix"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "phoenix"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  }
+, {
     "emoji": "🐸"
   , "description": "frog"
   , "category": "Animals & Nature"
@@ -8217,6 +8614,18 @@
   , "ios_version": "6.0"
   }
 , {
+    "emoji": "🫍"
+  , "description": "orca"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "orca"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "17.0"
+  , "ios_version": "26.4"
+  }
+, {
     "emoji": "🦭"
   , "description": "seal"
   , "category": "Animals & Nature"
@@ -8325,6 +8734,66 @@
     ]
   , "unicode_version": "15.0"
   , "ios_version": "16.4"
+  }
+, {
+    "emoji": "🦀"
+  , "description": "crab"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "crab"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "8.0"
+  , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🦞"
+  , "description": "lobster"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "lobster"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "11.0"
+  , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🦐"
+  , "description": "shrimp"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "shrimp"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🦑"
+  , "description": "squid"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "squid"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "9.0"
+  , "ios_version": "10.2"
+  }
+, {
+    "emoji": "🦪"
+  , "description": "oyster"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "oyster"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "12.0"
+  , "ios_version": "13.0"
   }
 , {
     "emoji": "🐌"
@@ -8872,6 +9341,18 @@
   , "ios_version": "6.0"
   }
 , {
+    "emoji": "🪾"
+  , "description": "leafless tree"
+  , "category": "Animals & Nature"
+  , "aliases": [
+      "leafless_tree"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "16.0"
+  , "ios_version": "18.4"
+  }
+, {
     "emoji": "🍇"
   , "description": "grapes"
   , "category": "Food & Drink"
@@ -8932,6 +9413,18 @@
     ]
   , "unicode_version": "6.0"
   , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🍋‍🟩"
+  , "description": "lime"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "lime"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
   }
 , {
     "emoji": "🍌"
@@ -9310,6 +9803,30 @@
     ]
   , "unicode_version": "15.0"
   , "ios_version": "16.4"
+  }
+, {
+    "emoji": "🍄‍🟫"
+  , "description": "brown mushroom"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "brown_mushroom"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  }
+, {
+    "emoji": "🫜"
+  , "description": "root vegetable"
+  , "category": "Food & Drink"
+  , "aliases": [
+      "root_vegetable"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "16.0"
+  , "ios_version": "18.4"
   }
 , {
     "emoji": "🍞"
@@ -9932,66 +10449,6 @@
     ]
   , "unicode_version": "11.0"
   , "ios_version": "12.1"
-  }
-, {
-    "emoji": "🦀"
-  , "description": "crab"
-  , "category": "Food & Drink"
-  , "aliases": [
-      "crab"
-    ]
-  , "tags": [
-    ]
-  , "unicode_version": "8.0"
-  , "ios_version": "9.1"
-  }
-, {
-    "emoji": "🦞"
-  , "description": "lobster"
-  , "category": "Food & Drink"
-  , "aliases": [
-      "lobster"
-    ]
-  , "tags": [
-    ]
-  , "unicode_version": "11.0"
-  , "ios_version": "12.1"
-  }
-, {
-    "emoji": "🦐"
-  , "description": "shrimp"
-  , "category": "Food & Drink"
-  , "aliases": [
-      "shrimp"
-    ]
-  , "tags": [
-    ]
-  , "unicode_version": "9.0"
-  , "ios_version": "10.2"
-  }
-, {
-    "emoji": "🦑"
-  , "description": "squid"
-  , "category": "Food & Drink"
-  , "aliases": [
-      "squid"
-    ]
-  , "tags": [
-    ]
-  , "unicode_version": "9.0"
-  , "ios_version": "10.2"
-  }
-, {
-    "emoji": "🦪"
-  , "description": "oyster"
-  , "category": "Food & Drink"
-  , "aliases": [
-      "oyster"
-    ]
-  , "tags": [
-    ]
-  , "unicode_version": "12.0"
-  , "ios_version": "13.0"
   }
 , {
     "emoji": "🍦"
@@ -10630,6 +11087,18 @@
     ]
   , "unicode_version": "5.2"
   , "ios_version": "9.1"
+  }
+, {
+    "emoji": "🛘"
+  , "description": "landslide"
+  , "category": "Travel & Places"
+  , "aliases": [
+      "landslide"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "17.0"
+  , "ios_version": "26.4"
   }
 , {
     "emoji": "🌋"
@@ -15092,6 +15561,30 @@
   , "ios_version": "6.0"
   }
 , {
+    "emoji": "🎺"
+  , "description": "trumpet"
+  , "category": "Objects"
+  , "aliases": [
+      "trumpet"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "6.0"
+  , "ios_version": "6.0"
+  }
+, {
+    "emoji": "🪊"
+  , "description": "trombone"
+  , "category": "Objects"
+  , "aliases": [
+      "trombone"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "17.0"
+  , "ios_version": "26.4"
+  }
+, {
     "emoji": "🪗"
   , "description": "accordion"
   , "category": "Objects"
@@ -15125,18 +15618,6 @@
     ]
   , "tags": [
       "piano"
-    ]
-  , "unicode_version": "6.0"
-  , "ios_version": "6.0"
-  }
-, {
-    "emoji": "🎺"
-  , "description": "trumpet"
-  , "category": "Objects"
-  , "aliases": [
-      "trumpet"
-    ]
-  , "tags": [
     ]
   , "unicode_version": "6.0"
   , "ios_version": "6.0"
@@ -15214,6 +15695,18 @@
     ]
   , "unicode_version": "15.0"
   , "ios_version": "16.4"
+  }
+, {
+    "emoji": "🪉"
+  , "description": "harp"
+  , "category": "Objects"
+  , "aliases": [
+      "harp"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "16.0"
+  , "ios_version": "18.4"
   }
 , {
     "emoji": "📱"
@@ -15880,6 +16373,18 @@
   , "ios_version": "9.1"
   }
 , {
+    "emoji": "🪙"
+  , "description": "coin"
+  , "category": "Objects"
+  , "aliases": [
+      "coin"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "13.0"
+  , "ios_version": "14.0"
+  }
+, {
     "emoji": "💰"
   , "description": "money bag"
   , "category": "Objects"
@@ -15894,16 +16399,16 @@
   , "ios_version": "6.0"
   }
 , {
-    "emoji": "🪙"
-  , "description": "coin"
+    "emoji": "🪎"
+  , "description": "treasure chest"
   , "category": "Objects"
   , "aliases": [
-      "coin"
+      "treasure_chest"
     ]
   , "tags": [
     ]
-  , "unicode_version": "13.0"
-  , "ios_version": "14.0"
+  , "unicode_version": "17.0"
+  , "ios_version": "26.4"
   }
 , {
     "emoji": "💴"
@@ -16865,6 +17370,18 @@
   , "ios_version": "6.0"
   }
 , {
+    "emoji": "⛓️‍💥"
+  , "description": "broken chain"
+  , "category": "Objects"
+  , "aliases": [
+      "broken_chain"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "15.1"
+  , "ios_version": "17.4"
+  }
+, {
     "emoji": "⛓️"
   , "description": "chains"
   , "category": "Objects"
@@ -16923,6 +17440,18 @@
     ]
   , "unicode_version": "13.0"
   , "ios_version": "14.0"
+  }
+, {
+    "emoji": "🪏"
+  , "description": "shovel"
+  , "category": "Objects"
+  , "aliases": [
+      "shovel"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "16.0"
+  , "ios_version": "18.4"
   }
 , {
     "emoji": "⚗️"
@@ -19185,6 +19714,18 @@
   , "ios_version": "6.0"
   }
 , {
+    "emoji": "🫟"
+  , "description": "splatter"
+  , "category": "Symbols"
+  , "aliases": [
+      "splatter"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "16.0"
+  , "ios_version": "18.4"
+  }
+, {
     "emoji": "#️⃣"
   , "description": "keycap: #"
   , "category": "Symbols"
@@ -20937,6 +21478,18 @@
     ]
   , "unicode_version": "11.0"
   , "ios_version": "12.1"
+  }
+, {
+    "emoji": "🇨🇶"
+  , "description": "flag: Sark"
+  , "category": "Flags"
+  , "aliases": [
+      "flag_sark"
+    ]
+  , "tags": [
+    ]
+  , "unicode_version": "16.0"
+  , "ios_version": "18.4"
   }
 , {
     "emoji": "🇨🇷"
@@ -23114,7 +23667,7 @@
   }
 , {
     "emoji": "🇹🇷"
-  , "description": "flag: Turkey"
+  , "description": "flag: Türkiye"
   , "category": "Flags"
   , "aliases": [
       "tr"

--- a/vendor/unicode-emoji-test.txt
+++ b/vendor/unicode-emoji-test.txt
@@ -1,11 +1,11 @@
 # emoji-test.txt
-# Date: 2022-08-12, 20:24:39 GMT
-# © 2022 Unicode®, Inc.
+# Date: 2025-08-04, 20:55:31 GMT
+# © 2025 Unicode®, Inc.
 # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
-# For terms of use, see https://www.unicode.org/terms_of_use.html
+# For terms of use and license, see https://www.unicode.org/terms_of_use.html
 #
 # Emoji Keyboard/Display Test Data for UTS #51
-# Version: 15.0
+# Version: 17.0
 #
 # For documentation and usage, see https://www.unicode.org/reports/tr51
 #
@@ -14,16 +14,20 @@
 #     Code points — list of one or more hex code points, separated by spaces
 #     Status
 #       component           — an Emoji_Component,
-#                             excluding Regional_Indicators, ASCII, and non-Emoji.
+#                             excluding Regional_Indicator, ASCII, and non-Emoji
 #       fully-qualified     — a fully-qualified emoji (see ED-18 in UTS #51),
 #                             excluding Emoji_Component
 #       minimally-qualified — a minimally-qualified emoji (see ED-18a in UTS #51)
-#       unqualified         — a unqualified emoji (See ED-19 in UTS #51)
+#       unqualified         — an unqualified emoji (see ED-19 in UTS #51)
 # Notes:
+#   • A mapping of these status values to RGI_Emoji_Qualification property values
+#     is given by ED-28 in UTS #51.
 #   • This includes the emoji components that need emoji presentation (skin tone and hair)
 #     when isolated, but omits the components that need not have an emoji
-#     presentation when isolated.
-#   • The RGI set is covered by the listed fully-qualified emoji. 
+#     presentation when isolated. See ED-20 in UTS #51 for further information.
+#   • The RGI emoji set corresponds to the RGI_Emoji property and contains the same sequences
+#     as the union of the sets of component and fully-qualified sequences in this file.
+#     See ED-27 in UTS #51 for further information.
 #   • The listed minimally-qualified and unqualified cover all cases where an
 #     element of the RGI set is missing one or more emoji presentation selectors.
 #   • The file is in CLDR order, not codepoint order. This is recommended (but not required!) for keyboard palettes.
@@ -93,6 +97,10 @@
 1F62E 200D 1F4A8                                       ; fully-qualified     # 😮‍💨 E13.1 face exhaling
 1F925                                                  ; fully-qualified     # 🤥 E3.0 lying face
 1FAE8                                                  ; fully-qualified     # 🫨 E15.0 shaking face
+1F642 200D 2194 FE0F                                   ; fully-qualified     # 🙂‍↔️ E15.1 head shaking horizontally
+1F642 200D 2194                                        ; minimally-qualified # 🙂‍↔ E15.1 head shaking horizontally
+1F642 200D 2195 FE0F                                   ; fully-qualified     # 🙂‍↕️ E15.1 head shaking vertically
+1F642 200D 2195                                        ; minimally-qualified # 🙂‍↕ E15.1 head shaking vertically
 
 # subgroup: face-sleepy
 1F60C                                                  ; fully-qualified     # 😌 E0.6 relieved face
@@ -100,6 +108,7 @@
 1F62A                                                  ; fully-qualified     # 😪 E0.6 sleepy face
 1F924                                                  ; fully-qualified     # 🤤 E3.0 drooling face
 1F634                                                  ; fully-qualified     # 😴 E1.0 sleeping face
+1FAE9                                                  ; fully-qualified     # 🫩 E16.0 face with bags under eyes
 
 # subgroup: face-unwell
 1F637                                                  ; fully-qualified     # 😷 E0.6 face with medical mask
@@ -136,6 +145,7 @@
 1F62F                                                  ; fully-qualified     # 😯 E1.0 hushed face
 1F632                                                  ; fully-qualified     # 😲 E0.6 astonished face
 1F633                                                  ; fully-qualified     # 😳 E0.6 flushed face
+1FAEA                                                  ; fully-qualified     # 🫪 E17.0 distorted face
 1F97A                                                  ; fully-qualified     # 🥺 E11.0 pleading face
 1F979                                                  ; fully-qualified     # 🥹 E14.0 face holding back tears
 1F626                                                  ; fully-qualified     # 😦 E1.0 frowning face with open mouth
@@ -226,6 +236,7 @@
 1F48B                                                  ; fully-qualified     # 💋 E0.6 kiss mark
 1F4AF                                                  ; fully-qualified     # 💯 E0.6 hundred points
 1F4A2                                                  ; fully-qualified     # 💢 E0.6 anger symbol
+1FAEF                                                  ; fully-qualified     # 🫯 E17.0 fight cloud
 1F4A5                                                  ; fully-qualified     # 💥 E0.6 collision
 1F4AB                                                  ; fully-qualified     # 💫 E0.6 dizzy
 1F4A6                                                  ; fully-qualified     # 💦 E0.6 sweat droplets
@@ -244,8 +255,8 @@
 1F4AD                                                  ; fully-qualified     # 💭 E1.0 thought balloon
 1F4A4                                                  ; fully-qualified     # 💤 E0.6 ZZZ
 
-# Smileys & Emotion subtotal:		180
-# Smileys & Emotion subtotal:		180	w/o modifiers
+# Smileys & Emotion subtotal:		187
+# Smileys & Emotion subtotal:		187	w/o modifiers
 
 # group: People & Body
 
@@ -1746,12 +1757,12 @@
 1F936 1F3FD                                            ; fully-qualified     # 🤶🏽 E3.0 Mrs. Claus: medium skin tone
 1F936 1F3FE                                            ; fully-qualified     # 🤶🏾 E3.0 Mrs. Claus: medium-dark skin tone
 1F936 1F3FF                                            ; fully-qualified     # 🤶🏿 E3.0 Mrs. Claus: dark skin tone
-1F9D1 200D 1F384                                       ; fully-qualified     # 🧑‍🎄 E13.0 mx claus
-1F9D1 1F3FB 200D 1F384                                 ; fully-qualified     # 🧑🏻‍🎄 E13.0 mx claus: light skin tone
-1F9D1 1F3FC 200D 1F384                                 ; fully-qualified     # 🧑🏼‍🎄 E13.0 mx claus: medium-light skin tone
-1F9D1 1F3FD 200D 1F384                                 ; fully-qualified     # 🧑🏽‍🎄 E13.0 mx claus: medium skin tone
-1F9D1 1F3FE 200D 1F384                                 ; fully-qualified     # 🧑🏾‍🎄 E13.0 mx claus: medium-dark skin tone
-1F9D1 1F3FF 200D 1F384                                 ; fully-qualified     # 🧑🏿‍🎄 E13.0 mx claus: dark skin tone
+1F9D1 200D 1F384                                       ; fully-qualified     # 🧑‍🎄 E13.0 Mx Claus
+1F9D1 1F3FB 200D 1F384                                 ; fully-qualified     # 🧑🏻‍🎄 E13.0 Mx Claus: light skin tone
+1F9D1 1F3FC 200D 1F384                                 ; fully-qualified     # 🧑🏼‍🎄 E13.0 Mx Claus: medium-light skin tone
+1F9D1 1F3FD 200D 1F384                                 ; fully-qualified     # 🧑🏽‍🎄 E13.0 Mx Claus: medium skin tone
+1F9D1 1F3FE 200D 1F384                                 ; fully-qualified     # 🧑🏾‍🎄 E13.0 Mx Claus: medium-dark skin tone
+1F9D1 1F3FF 200D 1F384                                 ; fully-qualified     # 🧑🏿‍🎄 E13.0 Mx Claus: dark skin tone
 1F9B8                                                  ; fully-qualified     # 🦸 E11.0 superhero
 1F9B8 1F3FB                                            ; fully-qualified     # 🦸🏻 E11.0 superhero: light skin tone
 1F9B8 1F3FC                                            ; fully-qualified     # 🦸🏼 E11.0 superhero: medium-light skin tone
@@ -1973,6 +1984,7 @@
 1F9DF 200D 2640 FE0F                                   ; fully-qualified     # 🧟‍♀️ E5.0 woman zombie
 1F9DF 200D 2640                                        ; minimally-qualified # 🧟‍♀ E5.0 woman zombie
 1F9CC                                                  ; fully-qualified     # 🧌 E14.0 troll
+1FAC8                                                  ; fully-qualified     # 🫈 E17.0 hairy creature
 
 # subgroup: person-activity
 1F486                                                  ; fully-qualified     # 💆 E0.6 person getting massage
@@ -2065,6 +2077,66 @@
 1F6B6 1F3FE 200D 2640                                  ; minimally-qualified # 🚶🏾‍♀ E4.0 woman walking: medium-dark skin tone
 1F6B6 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🚶🏿‍♀️ E4.0 woman walking: dark skin tone
 1F6B6 1F3FF 200D 2640                                  ; minimally-qualified # 🚶🏿‍♀ E4.0 woman walking: dark skin tone
+1F6B6 200D 27A1 FE0F                                   ; fully-qualified     # 🚶‍➡️ E15.1 person walking facing right
+1F6B6 200D 27A1                                        ; minimally-qualified # 🚶‍➡ E15.1 person walking facing right
+1F6B6 1F3FB 200D 27A1 FE0F                             ; fully-qualified     # 🚶🏻‍➡️ E15.1 person walking facing right: light skin tone
+1F6B6 1F3FB 200D 27A1                                  ; minimally-qualified # 🚶🏻‍➡ E15.1 person walking facing right: light skin tone
+1F6B6 1F3FC 200D 27A1 FE0F                             ; fully-qualified     # 🚶🏼‍➡️ E15.1 person walking facing right: medium-light skin tone
+1F6B6 1F3FC 200D 27A1                                  ; minimally-qualified # 🚶🏼‍➡ E15.1 person walking facing right: medium-light skin tone
+1F6B6 1F3FD 200D 27A1 FE0F                             ; fully-qualified     # 🚶🏽‍➡️ E15.1 person walking facing right: medium skin tone
+1F6B6 1F3FD 200D 27A1                                  ; minimally-qualified # 🚶🏽‍➡ E15.1 person walking facing right: medium skin tone
+1F6B6 1F3FE 200D 27A1 FE0F                             ; fully-qualified     # 🚶🏾‍➡️ E15.1 person walking facing right: medium-dark skin tone
+1F6B6 1F3FE 200D 27A1                                  ; minimally-qualified # 🚶🏾‍➡ E15.1 person walking facing right: medium-dark skin tone
+1F6B6 1F3FF 200D 27A1 FE0F                             ; fully-qualified     # 🚶🏿‍➡️ E15.1 person walking facing right: dark skin tone
+1F6B6 1F3FF 200D 27A1                                  ; minimally-qualified # 🚶🏿‍➡ E15.1 person walking facing right: dark skin tone
+1F6B6 200D 2640 FE0F 200D 27A1 FE0F                    ; fully-qualified     # 🚶‍♀️‍➡️ E15.1 woman walking facing right
+1F6B6 200D 2640 200D 27A1 FE0F                         ; minimally-qualified # 🚶‍♀‍➡️ E15.1 woman walking facing right
+1F6B6 200D 2640 FE0F 200D 27A1                         ; minimally-qualified # 🚶‍♀️‍➡ E15.1 woman walking facing right
+1F6B6 200D 2640 200D 27A1                              ; minimally-qualified # 🚶‍♀‍➡ E15.1 woman walking facing right
+1F6B6 1F3FB 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏻‍♀️‍➡️ E15.1 woman walking facing right: light skin tone
+1F6B6 1F3FB 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏻‍♀‍➡️ E15.1 woman walking facing right: light skin tone
+1F6B6 1F3FB 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏻‍♀️‍➡ E15.1 woman walking facing right: light skin tone
+1F6B6 1F3FB 200D 2640 200D 27A1                        ; minimally-qualified # 🚶🏻‍♀‍➡ E15.1 woman walking facing right: light skin tone
+1F6B6 1F3FC 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏼‍♀️‍➡️ E15.1 woman walking facing right: medium-light skin tone
+1F6B6 1F3FC 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏼‍♀‍➡️ E15.1 woman walking facing right: medium-light skin tone
+1F6B6 1F3FC 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏼‍♀️‍➡ E15.1 woman walking facing right: medium-light skin tone
+1F6B6 1F3FC 200D 2640 200D 27A1                        ; minimally-qualified # 🚶🏼‍♀‍➡ E15.1 woman walking facing right: medium-light skin tone
+1F6B6 1F3FD 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏽‍♀️‍➡️ E15.1 woman walking facing right: medium skin tone
+1F6B6 1F3FD 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏽‍♀‍➡️ E15.1 woman walking facing right: medium skin tone
+1F6B6 1F3FD 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏽‍♀️‍➡ E15.1 woman walking facing right: medium skin tone
+1F6B6 1F3FD 200D 2640 200D 27A1                        ; minimally-qualified # 🚶🏽‍♀‍➡ E15.1 woman walking facing right: medium skin tone
+1F6B6 1F3FE 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏾‍♀️‍➡️ E15.1 woman walking facing right: medium-dark skin tone
+1F6B6 1F3FE 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏾‍♀‍➡️ E15.1 woman walking facing right: medium-dark skin tone
+1F6B6 1F3FE 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏾‍♀️‍➡ E15.1 woman walking facing right: medium-dark skin tone
+1F6B6 1F3FE 200D 2640 200D 27A1                        ; minimally-qualified # 🚶🏾‍♀‍➡ E15.1 woman walking facing right: medium-dark skin tone
+1F6B6 1F3FF 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏿‍♀️‍➡️ E15.1 woman walking facing right: dark skin tone
+1F6B6 1F3FF 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏿‍♀‍➡️ E15.1 woman walking facing right: dark skin tone
+1F6B6 1F3FF 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏿‍♀️‍➡ E15.1 woman walking facing right: dark skin tone
+1F6B6 1F3FF 200D 2640 200D 27A1                        ; minimally-qualified # 🚶🏿‍♀‍➡ E15.1 woman walking facing right: dark skin tone
+1F6B6 200D 2642 FE0F 200D 27A1 FE0F                    ; fully-qualified     # 🚶‍♂️‍➡️ E15.1 man walking facing right
+1F6B6 200D 2642 200D 27A1 FE0F                         ; minimally-qualified # 🚶‍♂‍➡️ E15.1 man walking facing right
+1F6B6 200D 2642 FE0F 200D 27A1                         ; minimally-qualified # 🚶‍♂️‍➡ E15.1 man walking facing right
+1F6B6 200D 2642 200D 27A1                              ; minimally-qualified # 🚶‍♂‍➡ E15.1 man walking facing right
+1F6B6 1F3FB 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏻‍♂️‍➡️ E15.1 man walking facing right: light skin tone
+1F6B6 1F3FB 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏻‍♂‍➡️ E15.1 man walking facing right: light skin tone
+1F6B6 1F3FB 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏻‍♂️‍➡ E15.1 man walking facing right: light skin tone
+1F6B6 1F3FB 200D 2642 200D 27A1                        ; minimally-qualified # 🚶🏻‍♂‍➡ E15.1 man walking facing right: light skin tone
+1F6B6 1F3FC 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏼‍♂️‍➡️ E15.1 man walking facing right: medium-light skin tone
+1F6B6 1F3FC 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏼‍♂‍➡️ E15.1 man walking facing right: medium-light skin tone
+1F6B6 1F3FC 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏼‍♂️‍➡ E15.1 man walking facing right: medium-light skin tone
+1F6B6 1F3FC 200D 2642 200D 27A1                        ; minimally-qualified # 🚶🏼‍♂‍➡ E15.1 man walking facing right: medium-light skin tone
+1F6B6 1F3FD 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏽‍♂️‍➡️ E15.1 man walking facing right: medium skin tone
+1F6B6 1F3FD 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏽‍♂‍➡️ E15.1 man walking facing right: medium skin tone
+1F6B6 1F3FD 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏽‍♂️‍➡ E15.1 man walking facing right: medium skin tone
+1F6B6 1F3FD 200D 2642 200D 27A1                        ; minimally-qualified # 🚶🏽‍♂‍➡ E15.1 man walking facing right: medium skin tone
+1F6B6 1F3FE 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏾‍♂️‍➡️ E15.1 man walking facing right: medium-dark skin tone
+1F6B6 1F3FE 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏾‍♂‍➡️ E15.1 man walking facing right: medium-dark skin tone
+1F6B6 1F3FE 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏾‍♂️‍➡ E15.1 man walking facing right: medium-dark skin tone
+1F6B6 1F3FE 200D 2642 200D 27A1                        ; minimally-qualified # 🚶🏾‍♂‍➡ E15.1 man walking facing right: medium-dark skin tone
+1F6B6 1F3FF 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🚶🏿‍♂️‍➡️ E15.1 man walking facing right: dark skin tone
+1F6B6 1F3FF 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🚶🏿‍♂‍➡️ E15.1 man walking facing right: dark skin tone
+1F6B6 1F3FF 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🚶🏿‍♂️‍➡ E15.1 man walking facing right: dark skin tone
+1F6B6 1F3FF 200D 2642 200D 27A1                        ; minimally-qualified # 🚶🏿‍♂‍➡ E15.1 man walking facing right: dark skin tone
 1F9CD                                                  ; fully-qualified     # 🧍 E12.0 person standing
 1F9CD 1F3FB                                            ; fully-qualified     # 🧍🏻 E12.0 person standing: light skin tone
 1F9CD 1F3FC                                            ; fully-qualified     # 🧍🏼 E12.0 person standing: medium-light skin tone
@@ -2125,60 +2197,228 @@
 1F9CE 1F3FE 200D 2640                                  ; minimally-qualified # 🧎🏾‍♀ E12.0 woman kneeling: medium-dark skin tone
 1F9CE 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🧎🏿‍♀️ E12.0 woman kneeling: dark skin tone
 1F9CE 1F3FF 200D 2640                                  ; minimally-qualified # 🧎🏿‍♀ E12.0 woman kneeling: dark skin tone
+1F9CE 200D 27A1 FE0F                                   ; fully-qualified     # 🧎‍➡️ E15.1 person kneeling facing right
+1F9CE 200D 27A1                                        ; minimally-qualified # 🧎‍➡ E15.1 person kneeling facing right
+1F9CE 1F3FB 200D 27A1 FE0F                             ; fully-qualified     # 🧎🏻‍➡️ E15.1 person kneeling facing right: light skin tone
+1F9CE 1F3FB 200D 27A1                                  ; minimally-qualified # 🧎🏻‍➡ E15.1 person kneeling facing right: light skin tone
+1F9CE 1F3FC 200D 27A1 FE0F                             ; fully-qualified     # 🧎🏼‍➡️ E15.1 person kneeling facing right: medium-light skin tone
+1F9CE 1F3FC 200D 27A1                                  ; minimally-qualified # 🧎🏼‍➡ E15.1 person kneeling facing right: medium-light skin tone
+1F9CE 1F3FD 200D 27A1 FE0F                             ; fully-qualified     # 🧎🏽‍➡️ E15.1 person kneeling facing right: medium skin tone
+1F9CE 1F3FD 200D 27A1                                  ; minimally-qualified # 🧎🏽‍➡ E15.1 person kneeling facing right: medium skin tone
+1F9CE 1F3FE 200D 27A1 FE0F                             ; fully-qualified     # 🧎🏾‍➡️ E15.1 person kneeling facing right: medium-dark skin tone
+1F9CE 1F3FE 200D 27A1                                  ; minimally-qualified # 🧎🏾‍➡ E15.1 person kneeling facing right: medium-dark skin tone
+1F9CE 1F3FF 200D 27A1 FE0F                             ; fully-qualified     # 🧎🏿‍➡️ E15.1 person kneeling facing right: dark skin tone
+1F9CE 1F3FF 200D 27A1                                  ; minimally-qualified # 🧎🏿‍➡ E15.1 person kneeling facing right: dark skin tone
+1F9CE 200D 2640 FE0F 200D 27A1 FE0F                    ; fully-qualified     # 🧎‍♀️‍➡️ E15.1 woman kneeling facing right
+1F9CE 200D 2640 200D 27A1 FE0F                         ; minimally-qualified # 🧎‍♀‍➡️ E15.1 woman kneeling facing right
+1F9CE 200D 2640 FE0F 200D 27A1                         ; minimally-qualified # 🧎‍♀️‍➡ E15.1 woman kneeling facing right
+1F9CE 200D 2640 200D 27A1                              ; minimally-qualified # 🧎‍♀‍➡ E15.1 woman kneeling facing right
+1F9CE 1F3FB 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏻‍♀️‍➡️ E15.1 woman kneeling facing right: light skin tone
+1F9CE 1F3FB 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏻‍♀‍➡️ E15.1 woman kneeling facing right: light skin tone
+1F9CE 1F3FB 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏻‍♀️‍➡ E15.1 woman kneeling facing right: light skin tone
+1F9CE 1F3FB 200D 2640 200D 27A1                        ; minimally-qualified # 🧎🏻‍♀‍➡ E15.1 woman kneeling facing right: light skin tone
+1F9CE 1F3FC 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏼‍♀️‍➡️ E15.1 woman kneeling facing right: medium-light skin tone
+1F9CE 1F3FC 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏼‍♀‍➡️ E15.1 woman kneeling facing right: medium-light skin tone
+1F9CE 1F3FC 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏼‍♀️‍➡ E15.1 woman kneeling facing right: medium-light skin tone
+1F9CE 1F3FC 200D 2640 200D 27A1                        ; minimally-qualified # 🧎🏼‍♀‍➡ E15.1 woman kneeling facing right: medium-light skin tone
+1F9CE 1F3FD 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏽‍♀️‍➡️ E15.1 woman kneeling facing right: medium skin tone
+1F9CE 1F3FD 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏽‍♀‍➡️ E15.1 woman kneeling facing right: medium skin tone
+1F9CE 1F3FD 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏽‍♀️‍➡ E15.1 woman kneeling facing right: medium skin tone
+1F9CE 1F3FD 200D 2640 200D 27A1                        ; minimally-qualified # 🧎🏽‍♀‍➡ E15.1 woman kneeling facing right: medium skin tone
+1F9CE 1F3FE 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏾‍♀️‍➡️ E15.1 woman kneeling facing right: medium-dark skin tone
+1F9CE 1F3FE 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏾‍♀‍➡️ E15.1 woman kneeling facing right: medium-dark skin tone
+1F9CE 1F3FE 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏾‍♀️‍➡ E15.1 woman kneeling facing right: medium-dark skin tone
+1F9CE 1F3FE 200D 2640 200D 27A1                        ; minimally-qualified # 🧎🏾‍♀‍➡ E15.1 woman kneeling facing right: medium-dark skin tone
+1F9CE 1F3FF 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏿‍♀️‍➡️ E15.1 woman kneeling facing right: dark skin tone
+1F9CE 1F3FF 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏿‍♀‍➡️ E15.1 woman kneeling facing right: dark skin tone
+1F9CE 1F3FF 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏿‍♀️‍➡ E15.1 woman kneeling facing right: dark skin tone
+1F9CE 1F3FF 200D 2640 200D 27A1                        ; minimally-qualified # 🧎🏿‍♀‍➡ E15.1 woman kneeling facing right: dark skin tone
+1F9CE 200D 2642 FE0F 200D 27A1 FE0F                    ; fully-qualified     # 🧎‍♂️‍➡️ E15.1 man kneeling facing right
+1F9CE 200D 2642 200D 27A1 FE0F                         ; minimally-qualified # 🧎‍♂‍➡️ E15.1 man kneeling facing right
+1F9CE 200D 2642 FE0F 200D 27A1                         ; minimally-qualified # 🧎‍♂️‍➡ E15.1 man kneeling facing right
+1F9CE 200D 2642 200D 27A1                              ; minimally-qualified # 🧎‍♂‍➡ E15.1 man kneeling facing right
+1F9CE 1F3FB 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏻‍♂️‍➡️ E15.1 man kneeling facing right: light skin tone
+1F9CE 1F3FB 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏻‍♂‍➡️ E15.1 man kneeling facing right: light skin tone
+1F9CE 1F3FB 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏻‍♂️‍➡ E15.1 man kneeling facing right: light skin tone
+1F9CE 1F3FB 200D 2642 200D 27A1                        ; minimally-qualified # 🧎🏻‍♂‍➡ E15.1 man kneeling facing right: light skin tone
+1F9CE 1F3FC 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏼‍♂️‍➡️ E15.1 man kneeling facing right: medium-light skin tone
+1F9CE 1F3FC 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏼‍♂‍➡️ E15.1 man kneeling facing right: medium-light skin tone
+1F9CE 1F3FC 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏼‍♂️‍➡ E15.1 man kneeling facing right: medium-light skin tone
+1F9CE 1F3FC 200D 2642 200D 27A1                        ; minimally-qualified # 🧎🏼‍♂‍➡ E15.1 man kneeling facing right: medium-light skin tone
+1F9CE 1F3FD 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏽‍♂️‍➡️ E15.1 man kneeling facing right: medium skin tone
+1F9CE 1F3FD 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏽‍♂‍➡️ E15.1 man kneeling facing right: medium skin tone
+1F9CE 1F3FD 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏽‍♂️‍➡ E15.1 man kneeling facing right: medium skin tone
+1F9CE 1F3FD 200D 2642 200D 27A1                        ; minimally-qualified # 🧎🏽‍♂‍➡ E15.1 man kneeling facing right: medium skin tone
+1F9CE 1F3FE 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏾‍♂️‍➡️ E15.1 man kneeling facing right: medium-dark skin tone
+1F9CE 1F3FE 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏾‍♂‍➡️ E15.1 man kneeling facing right: medium-dark skin tone
+1F9CE 1F3FE 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏾‍♂️‍➡ E15.1 man kneeling facing right: medium-dark skin tone
+1F9CE 1F3FE 200D 2642 200D 27A1                        ; minimally-qualified # 🧎🏾‍♂‍➡ E15.1 man kneeling facing right: medium-dark skin tone
+1F9CE 1F3FF 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🧎🏿‍♂️‍➡️ E15.1 man kneeling facing right: dark skin tone
+1F9CE 1F3FF 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🧎🏿‍♂‍➡️ E15.1 man kneeling facing right: dark skin tone
+1F9CE 1F3FF 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🧎🏿‍♂️‍➡ E15.1 man kneeling facing right: dark skin tone
+1F9CE 1F3FF 200D 2642 200D 27A1                        ; minimally-qualified # 🧎🏿‍♂‍➡ E15.1 man kneeling facing right: dark skin tone
 1F9D1 200D 1F9AF                                       ; fully-qualified     # 🧑‍🦯 E12.1 person with white cane
 1F9D1 1F3FB 200D 1F9AF                                 ; fully-qualified     # 🧑🏻‍🦯 E12.1 person with white cane: light skin tone
 1F9D1 1F3FC 200D 1F9AF                                 ; fully-qualified     # 🧑🏼‍🦯 E12.1 person with white cane: medium-light skin tone
 1F9D1 1F3FD 200D 1F9AF                                 ; fully-qualified     # 🧑🏽‍🦯 E12.1 person with white cane: medium skin tone
 1F9D1 1F3FE 200D 1F9AF                                 ; fully-qualified     # 🧑🏾‍🦯 E12.1 person with white cane: medium-dark skin tone
 1F9D1 1F3FF 200D 1F9AF                                 ; fully-qualified     # 🧑🏿‍🦯 E12.1 person with white cane: dark skin tone
+1F9D1 200D 1F9AF 200D 27A1 FE0F                        ; fully-qualified     # 🧑‍🦯‍➡️ E15.1 person with white cane facing right
+1F9D1 200D 1F9AF 200D 27A1                             ; minimally-qualified # 🧑‍🦯‍➡ E15.1 person with white cane facing right
+1F9D1 1F3FB 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏻‍🦯‍➡️ E15.1 person with white cane facing right: light skin tone
+1F9D1 1F3FB 200D 1F9AF 200D 27A1                       ; minimally-qualified # 🧑🏻‍🦯‍➡ E15.1 person with white cane facing right: light skin tone
+1F9D1 1F3FC 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏼‍🦯‍➡️ E15.1 person with white cane facing right: medium-light skin tone
+1F9D1 1F3FC 200D 1F9AF 200D 27A1                       ; minimally-qualified # 🧑🏼‍🦯‍➡ E15.1 person with white cane facing right: medium-light skin tone
+1F9D1 1F3FD 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏽‍🦯‍➡️ E15.1 person with white cane facing right: medium skin tone
+1F9D1 1F3FD 200D 1F9AF 200D 27A1                       ; minimally-qualified # 🧑🏽‍🦯‍➡ E15.1 person with white cane facing right: medium skin tone
+1F9D1 1F3FE 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏾‍🦯‍➡️ E15.1 person with white cane facing right: medium-dark skin tone
+1F9D1 1F3FE 200D 1F9AF 200D 27A1                       ; minimally-qualified # 🧑🏾‍🦯‍➡ E15.1 person with white cane facing right: medium-dark skin tone
+1F9D1 1F3FF 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏿‍🦯‍➡️ E15.1 person with white cane facing right: dark skin tone
+1F9D1 1F3FF 200D 1F9AF 200D 27A1                       ; minimally-qualified # 🧑🏿‍🦯‍➡ E15.1 person with white cane facing right: dark skin tone
 1F468 200D 1F9AF                                       ; fully-qualified     # 👨‍🦯 E12.0 man with white cane
 1F468 1F3FB 200D 1F9AF                                 ; fully-qualified     # 👨🏻‍🦯 E12.0 man with white cane: light skin tone
 1F468 1F3FC 200D 1F9AF                                 ; fully-qualified     # 👨🏼‍🦯 E12.0 man with white cane: medium-light skin tone
 1F468 1F3FD 200D 1F9AF                                 ; fully-qualified     # 👨🏽‍🦯 E12.0 man with white cane: medium skin tone
 1F468 1F3FE 200D 1F9AF                                 ; fully-qualified     # 👨🏾‍🦯 E12.0 man with white cane: medium-dark skin tone
 1F468 1F3FF 200D 1F9AF                                 ; fully-qualified     # 👨🏿‍🦯 E12.0 man with white cane: dark skin tone
+1F468 200D 1F9AF 200D 27A1 FE0F                        ; fully-qualified     # 👨‍🦯‍➡️ E15.1 man with white cane facing right
+1F468 200D 1F9AF 200D 27A1                             ; minimally-qualified # 👨‍🦯‍➡ E15.1 man with white cane facing right
+1F468 1F3FB 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👨🏻‍🦯‍➡️ E15.1 man with white cane facing right: light skin tone
+1F468 1F3FB 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👨🏻‍🦯‍➡ E15.1 man with white cane facing right: light skin tone
+1F468 1F3FC 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👨🏼‍🦯‍➡️ E15.1 man with white cane facing right: medium-light skin tone
+1F468 1F3FC 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👨🏼‍🦯‍➡ E15.1 man with white cane facing right: medium-light skin tone
+1F468 1F3FD 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👨🏽‍🦯‍➡️ E15.1 man with white cane facing right: medium skin tone
+1F468 1F3FD 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👨🏽‍🦯‍➡ E15.1 man with white cane facing right: medium skin tone
+1F468 1F3FE 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👨🏾‍🦯‍➡️ E15.1 man with white cane facing right: medium-dark skin tone
+1F468 1F3FE 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👨🏾‍🦯‍➡ E15.1 man with white cane facing right: medium-dark skin tone
+1F468 1F3FF 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👨🏿‍🦯‍➡️ E15.1 man with white cane facing right: dark skin tone
+1F468 1F3FF 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👨🏿‍🦯‍➡ E15.1 man with white cane facing right: dark skin tone
 1F469 200D 1F9AF                                       ; fully-qualified     # 👩‍🦯 E12.0 woman with white cane
 1F469 1F3FB 200D 1F9AF                                 ; fully-qualified     # 👩🏻‍🦯 E12.0 woman with white cane: light skin tone
 1F469 1F3FC 200D 1F9AF                                 ; fully-qualified     # 👩🏼‍🦯 E12.0 woman with white cane: medium-light skin tone
 1F469 1F3FD 200D 1F9AF                                 ; fully-qualified     # 👩🏽‍🦯 E12.0 woman with white cane: medium skin tone
 1F469 1F3FE 200D 1F9AF                                 ; fully-qualified     # 👩🏾‍🦯 E12.0 woman with white cane: medium-dark skin tone
 1F469 1F3FF 200D 1F9AF                                 ; fully-qualified     # 👩🏿‍🦯 E12.0 woman with white cane: dark skin tone
+1F469 200D 1F9AF 200D 27A1 FE0F                        ; fully-qualified     # 👩‍🦯‍➡️ E15.1 woman with white cane facing right
+1F469 200D 1F9AF 200D 27A1                             ; minimally-qualified # 👩‍🦯‍➡ E15.1 woman with white cane facing right
+1F469 1F3FB 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👩🏻‍🦯‍➡️ E15.1 woman with white cane facing right: light skin tone
+1F469 1F3FB 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👩🏻‍🦯‍➡ E15.1 woman with white cane facing right: light skin tone
+1F469 1F3FC 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👩🏼‍🦯‍➡️ E15.1 woman with white cane facing right: medium-light skin tone
+1F469 1F3FC 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👩🏼‍🦯‍➡ E15.1 woman with white cane facing right: medium-light skin tone
+1F469 1F3FD 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👩🏽‍🦯‍➡️ E15.1 woman with white cane facing right: medium skin tone
+1F469 1F3FD 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👩🏽‍🦯‍➡ E15.1 woman with white cane facing right: medium skin tone
+1F469 1F3FE 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👩🏾‍🦯‍➡️ E15.1 woman with white cane facing right: medium-dark skin tone
+1F469 1F3FE 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👩🏾‍🦯‍➡ E15.1 woman with white cane facing right: medium-dark skin tone
+1F469 1F3FF 200D 1F9AF 200D 27A1 FE0F                  ; fully-qualified     # 👩🏿‍🦯‍➡️ E15.1 woman with white cane facing right: dark skin tone
+1F469 1F3FF 200D 1F9AF 200D 27A1                       ; minimally-qualified # 👩🏿‍🦯‍➡ E15.1 woman with white cane facing right: dark skin tone
 1F9D1 200D 1F9BC                                       ; fully-qualified     # 🧑‍🦼 E12.1 person in motorized wheelchair
 1F9D1 1F3FB 200D 1F9BC                                 ; fully-qualified     # 🧑🏻‍🦼 E12.1 person in motorized wheelchair: light skin tone
 1F9D1 1F3FC 200D 1F9BC                                 ; fully-qualified     # 🧑🏼‍🦼 E12.1 person in motorized wheelchair: medium-light skin tone
 1F9D1 1F3FD 200D 1F9BC                                 ; fully-qualified     # 🧑🏽‍🦼 E12.1 person in motorized wheelchair: medium skin tone
 1F9D1 1F3FE 200D 1F9BC                                 ; fully-qualified     # 🧑🏾‍🦼 E12.1 person in motorized wheelchair: medium-dark skin tone
 1F9D1 1F3FF 200D 1F9BC                                 ; fully-qualified     # 🧑🏿‍🦼 E12.1 person in motorized wheelchair: dark skin tone
+1F9D1 200D 1F9BC 200D 27A1 FE0F                        ; fully-qualified     # 🧑‍🦼‍➡️ E15.1 person in motorized wheelchair facing right
+1F9D1 200D 1F9BC 200D 27A1                             ; minimally-qualified # 🧑‍🦼‍➡ E15.1 person in motorized wheelchair facing right
+1F9D1 1F3FB 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏻‍🦼‍➡️ E15.1 person in motorized wheelchair facing right: light skin tone
+1F9D1 1F3FB 200D 1F9BC 200D 27A1                       ; minimally-qualified # 🧑🏻‍🦼‍➡ E15.1 person in motorized wheelchair facing right: light skin tone
+1F9D1 1F3FC 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏼‍🦼‍➡️ E15.1 person in motorized wheelchair facing right: medium-light skin tone
+1F9D1 1F3FC 200D 1F9BC 200D 27A1                       ; minimally-qualified # 🧑🏼‍🦼‍➡ E15.1 person in motorized wheelchair facing right: medium-light skin tone
+1F9D1 1F3FD 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏽‍🦼‍➡️ E15.1 person in motorized wheelchair facing right: medium skin tone
+1F9D1 1F3FD 200D 1F9BC 200D 27A1                       ; minimally-qualified # 🧑🏽‍🦼‍➡ E15.1 person in motorized wheelchair facing right: medium skin tone
+1F9D1 1F3FE 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏾‍🦼‍➡️ E15.1 person in motorized wheelchair facing right: medium-dark skin tone
+1F9D1 1F3FE 200D 1F9BC 200D 27A1                       ; minimally-qualified # 🧑🏾‍🦼‍➡ E15.1 person in motorized wheelchair facing right: medium-dark skin tone
+1F9D1 1F3FF 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏿‍🦼‍➡️ E15.1 person in motorized wheelchair facing right: dark skin tone
+1F9D1 1F3FF 200D 1F9BC 200D 27A1                       ; minimally-qualified # 🧑🏿‍🦼‍➡ E15.1 person in motorized wheelchair facing right: dark skin tone
 1F468 200D 1F9BC                                       ; fully-qualified     # 👨‍🦼 E12.0 man in motorized wheelchair
 1F468 1F3FB 200D 1F9BC                                 ; fully-qualified     # 👨🏻‍🦼 E12.0 man in motorized wheelchair: light skin tone
 1F468 1F3FC 200D 1F9BC                                 ; fully-qualified     # 👨🏼‍🦼 E12.0 man in motorized wheelchair: medium-light skin tone
 1F468 1F3FD 200D 1F9BC                                 ; fully-qualified     # 👨🏽‍🦼 E12.0 man in motorized wheelchair: medium skin tone
 1F468 1F3FE 200D 1F9BC                                 ; fully-qualified     # 👨🏾‍🦼 E12.0 man in motorized wheelchair: medium-dark skin tone
 1F468 1F3FF 200D 1F9BC                                 ; fully-qualified     # 👨🏿‍🦼 E12.0 man in motorized wheelchair: dark skin tone
+1F468 200D 1F9BC 200D 27A1 FE0F                        ; fully-qualified     # 👨‍🦼‍➡️ E15.1 man in motorized wheelchair facing right
+1F468 200D 1F9BC 200D 27A1                             ; minimally-qualified # 👨‍🦼‍➡ E15.1 man in motorized wheelchair facing right
+1F468 1F3FB 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👨🏻‍🦼‍➡️ E15.1 man in motorized wheelchair facing right: light skin tone
+1F468 1F3FB 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👨🏻‍🦼‍➡ E15.1 man in motorized wheelchair facing right: light skin tone
+1F468 1F3FC 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👨🏼‍🦼‍➡️ E15.1 man in motorized wheelchair facing right: medium-light skin tone
+1F468 1F3FC 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👨🏼‍🦼‍➡ E15.1 man in motorized wheelchair facing right: medium-light skin tone
+1F468 1F3FD 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👨🏽‍🦼‍➡️ E15.1 man in motorized wheelchair facing right: medium skin tone
+1F468 1F3FD 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👨🏽‍🦼‍➡ E15.1 man in motorized wheelchair facing right: medium skin tone
+1F468 1F3FE 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👨🏾‍🦼‍➡️ E15.1 man in motorized wheelchair facing right: medium-dark skin tone
+1F468 1F3FE 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👨🏾‍🦼‍➡ E15.1 man in motorized wheelchair facing right: medium-dark skin tone
+1F468 1F3FF 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👨🏿‍🦼‍➡️ E15.1 man in motorized wheelchair facing right: dark skin tone
+1F468 1F3FF 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👨🏿‍🦼‍➡ E15.1 man in motorized wheelchair facing right: dark skin tone
 1F469 200D 1F9BC                                       ; fully-qualified     # 👩‍🦼 E12.0 woman in motorized wheelchair
 1F469 1F3FB 200D 1F9BC                                 ; fully-qualified     # 👩🏻‍🦼 E12.0 woman in motorized wheelchair: light skin tone
 1F469 1F3FC 200D 1F9BC                                 ; fully-qualified     # 👩🏼‍🦼 E12.0 woman in motorized wheelchair: medium-light skin tone
 1F469 1F3FD 200D 1F9BC                                 ; fully-qualified     # 👩🏽‍🦼 E12.0 woman in motorized wheelchair: medium skin tone
 1F469 1F3FE 200D 1F9BC                                 ; fully-qualified     # 👩🏾‍🦼 E12.0 woman in motorized wheelchair: medium-dark skin tone
 1F469 1F3FF 200D 1F9BC                                 ; fully-qualified     # 👩🏿‍🦼 E12.0 woman in motorized wheelchair: dark skin tone
+1F469 200D 1F9BC 200D 27A1 FE0F                        ; fully-qualified     # 👩‍🦼‍➡️ E15.1 woman in motorized wheelchair facing right
+1F469 200D 1F9BC 200D 27A1                             ; minimally-qualified # 👩‍🦼‍➡ E15.1 woman in motorized wheelchair facing right
+1F469 1F3FB 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👩🏻‍🦼‍➡️ E15.1 woman in motorized wheelchair facing right: light skin tone
+1F469 1F3FB 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👩🏻‍🦼‍➡ E15.1 woman in motorized wheelchair facing right: light skin tone
+1F469 1F3FC 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👩🏼‍🦼‍➡️ E15.1 woman in motorized wheelchair facing right: medium-light skin tone
+1F469 1F3FC 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👩🏼‍🦼‍➡ E15.1 woman in motorized wheelchair facing right: medium-light skin tone
+1F469 1F3FD 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👩🏽‍🦼‍➡️ E15.1 woman in motorized wheelchair facing right: medium skin tone
+1F469 1F3FD 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👩🏽‍🦼‍➡ E15.1 woman in motorized wheelchair facing right: medium skin tone
+1F469 1F3FE 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👩🏾‍🦼‍➡️ E15.1 woman in motorized wheelchair facing right: medium-dark skin tone
+1F469 1F3FE 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👩🏾‍🦼‍➡ E15.1 woman in motorized wheelchair facing right: medium-dark skin tone
+1F469 1F3FF 200D 1F9BC 200D 27A1 FE0F                  ; fully-qualified     # 👩🏿‍🦼‍➡️ E15.1 woman in motorized wheelchair facing right: dark skin tone
+1F469 1F3FF 200D 1F9BC 200D 27A1                       ; minimally-qualified # 👩🏿‍🦼‍➡ E15.1 woman in motorized wheelchair facing right: dark skin tone
 1F9D1 200D 1F9BD                                       ; fully-qualified     # 🧑‍🦽 E12.1 person in manual wheelchair
 1F9D1 1F3FB 200D 1F9BD                                 ; fully-qualified     # 🧑🏻‍🦽 E12.1 person in manual wheelchair: light skin tone
 1F9D1 1F3FC 200D 1F9BD                                 ; fully-qualified     # 🧑🏼‍🦽 E12.1 person in manual wheelchair: medium-light skin tone
 1F9D1 1F3FD 200D 1F9BD                                 ; fully-qualified     # 🧑🏽‍🦽 E12.1 person in manual wheelchair: medium skin tone
 1F9D1 1F3FE 200D 1F9BD                                 ; fully-qualified     # 🧑🏾‍🦽 E12.1 person in manual wheelchair: medium-dark skin tone
 1F9D1 1F3FF 200D 1F9BD                                 ; fully-qualified     # 🧑🏿‍🦽 E12.1 person in manual wheelchair: dark skin tone
+1F9D1 200D 1F9BD 200D 27A1 FE0F                        ; fully-qualified     # 🧑‍🦽‍➡️ E15.1 person in manual wheelchair facing right
+1F9D1 200D 1F9BD 200D 27A1                             ; minimally-qualified # 🧑‍🦽‍➡ E15.1 person in manual wheelchair facing right
+1F9D1 1F3FB 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏻‍🦽‍➡️ E15.1 person in manual wheelchair facing right: light skin tone
+1F9D1 1F3FB 200D 1F9BD 200D 27A1                       ; minimally-qualified # 🧑🏻‍🦽‍➡ E15.1 person in manual wheelchair facing right: light skin tone
+1F9D1 1F3FC 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏼‍🦽‍➡️ E15.1 person in manual wheelchair facing right: medium-light skin tone
+1F9D1 1F3FC 200D 1F9BD 200D 27A1                       ; minimally-qualified # 🧑🏼‍🦽‍➡ E15.1 person in manual wheelchair facing right: medium-light skin tone
+1F9D1 1F3FD 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏽‍🦽‍➡️ E15.1 person in manual wheelchair facing right: medium skin tone
+1F9D1 1F3FD 200D 1F9BD 200D 27A1                       ; minimally-qualified # 🧑🏽‍🦽‍➡ E15.1 person in manual wheelchair facing right: medium skin tone
+1F9D1 1F3FE 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏾‍🦽‍➡️ E15.1 person in manual wheelchair facing right: medium-dark skin tone
+1F9D1 1F3FE 200D 1F9BD 200D 27A1                       ; minimally-qualified # 🧑🏾‍🦽‍➡ E15.1 person in manual wheelchair facing right: medium-dark skin tone
+1F9D1 1F3FF 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 🧑🏿‍🦽‍➡️ E15.1 person in manual wheelchair facing right: dark skin tone
+1F9D1 1F3FF 200D 1F9BD 200D 27A1                       ; minimally-qualified # 🧑🏿‍🦽‍➡ E15.1 person in manual wheelchair facing right: dark skin tone
 1F468 200D 1F9BD                                       ; fully-qualified     # 👨‍🦽 E12.0 man in manual wheelchair
 1F468 1F3FB 200D 1F9BD                                 ; fully-qualified     # 👨🏻‍🦽 E12.0 man in manual wheelchair: light skin tone
 1F468 1F3FC 200D 1F9BD                                 ; fully-qualified     # 👨🏼‍🦽 E12.0 man in manual wheelchair: medium-light skin tone
 1F468 1F3FD 200D 1F9BD                                 ; fully-qualified     # 👨🏽‍🦽 E12.0 man in manual wheelchair: medium skin tone
 1F468 1F3FE 200D 1F9BD                                 ; fully-qualified     # 👨🏾‍🦽 E12.0 man in manual wheelchair: medium-dark skin tone
 1F468 1F3FF 200D 1F9BD                                 ; fully-qualified     # 👨🏿‍🦽 E12.0 man in manual wheelchair: dark skin tone
+1F468 200D 1F9BD 200D 27A1 FE0F                        ; fully-qualified     # 👨‍🦽‍➡️ E15.1 man in manual wheelchair facing right
+1F468 200D 1F9BD 200D 27A1                             ; minimally-qualified # 👨‍🦽‍➡ E15.1 man in manual wheelchair facing right
+1F468 1F3FB 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👨🏻‍🦽‍➡️ E15.1 man in manual wheelchair facing right: light skin tone
+1F468 1F3FB 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👨🏻‍🦽‍➡ E15.1 man in manual wheelchair facing right: light skin tone
+1F468 1F3FC 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👨🏼‍🦽‍➡️ E15.1 man in manual wheelchair facing right: medium-light skin tone
+1F468 1F3FC 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👨🏼‍🦽‍➡ E15.1 man in manual wheelchair facing right: medium-light skin tone
+1F468 1F3FD 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👨🏽‍🦽‍➡️ E15.1 man in manual wheelchair facing right: medium skin tone
+1F468 1F3FD 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👨🏽‍🦽‍➡ E15.1 man in manual wheelchair facing right: medium skin tone
+1F468 1F3FE 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👨🏾‍🦽‍➡️ E15.1 man in manual wheelchair facing right: medium-dark skin tone
+1F468 1F3FE 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👨🏾‍🦽‍➡ E15.1 man in manual wheelchair facing right: medium-dark skin tone
+1F468 1F3FF 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👨🏿‍🦽‍➡️ E15.1 man in manual wheelchair facing right: dark skin tone
+1F468 1F3FF 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👨🏿‍🦽‍➡ E15.1 man in manual wheelchair facing right: dark skin tone
 1F469 200D 1F9BD                                       ; fully-qualified     # 👩‍🦽 E12.0 woman in manual wheelchair
 1F469 1F3FB 200D 1F9BD                                 ; fully-qualified     # 👩🏻‍🦽 E12.0 woman in manual wheelchair: light skin tone
 1F469 1F3FC 200D 1F9BD                                 ; fully-qualified     # 👩🏼‍🦽 E12.0 woman in manual wheelchair: medium-light skin tone
 1F469 1F3FD 200D 1F9BD                                 ; fully-qualified     # 👩🏽‍🦽 E12.0 woman in manual wheelchair: medium skin tone
 1F469 1F3FE 200D 1F9BD                                 ; fully-qualified     # 👩🏾‍🦽 E12.0 woman in manual wheelchair: medium-dark skin tone
 1F469 1F3FF 200D 1F9BD                                 ; fully-qualified     # 👩🏿‍🦽 E12.0 woman in manual wheelchair: dark skin tone
+1F469 200D 1F9BD 200D 27A1 FE0F                        ; fully-qualified     # 👩‍🦽‍➡️ E15.1 woman in manual wheelchair facing right
+1F469 200D 1F9BD 200D 27A1                             ; minimally-qualified # 👩‍🦽‍➡ E15.1 woman in manual wheelchair facing right
+1F469 1F3FB 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👩🏻‍🦽‍➡️ E15.1 woman in manual wheelchair facing right: light skin tone
+1F469 1F3FB 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👩🏻‍🦽‍➡ E15.1 woman in manual wheelchair facing right: light skin tone
+1F469 1F3FC 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👩🏼‍🦽‍➡️ E15.1 woman in manual wheelchair facing right: medium-light skin tone
+1F469 1F3FC 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👩🏼‍🦽‍➡ E15.1 woman in manual wheelchair facing right: medium-light skin tone
+1F469 1F3FD 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👩🏽‍🦽‍➡️ E15.1 woman in manual wheelchair facing right: medium skin tone
+1F469 1F3FD 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👩🏽‍🦽‍➡ E15.1 woman in manual wheelchair facing right: medium skin tone
+1F469 1F3FE 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👩🏾‍🦽‍➡️ E15.1 woman in manual wheelchair facing right: medium-dark skin tone
+1F469 1F3FE 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👩🏾‍🦽‍➡ E15.1 woman in manual wheelchair facing right: medium-dark skin tone
+1F469 1F3FF 200D 1F9BD 200D 27A1 FE0F                  ; fully-qualified     # 👩🏿‍🦽‍➡️ E15.1 woman in manual wheelchair facing right: dark skin tone
+1F469 1F3FF 200D 1F9BD 200D 27A1                       ; minimally-qualified # 👩🏿‍🦽‍➡ E15.1 woman in manual wheelchair facing right: dark skin tone
 1F3C3                                                  ; fully-qualified     # 🏃 E0.6 person running
 1F3C3 1F3FB                                            ; fully-qualified     # 🏃🏻 E1.0 person running: light skin tone
 1F3C3 1F3FC                                            ; fully-qualified     # 🏃🏼 E1.0 person running: medium-light skin tone
@@ -2209,6 +2449,72 @@
 1F3C3 1F3FE 200D 2640                                  ; minimally-qualified # 🏃🏾‍♀ E4.0 woman running: medium-dark skin tone
 1F3C3 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🏃🏿‍♀️ E4.0 woman running: dark skin tone
 1F3C3 1F3FF 200D 2640                                  ; minimally-qualified # 🏃🏿‍♀ E4.0 woman running: dark skin tone
+1F3C3 200D 27A1 FE0F                                   ; fully-qualified     # 🏃‍➡️ E15.1 person running facing right
+1F3C3 200D 27A1                                        ; minimally-qualified # 🏃‍➡ E15.1 person running facing right
+1F3C3 1F3FB 200D 27A1 FE0F                             ; fully-qualified     # 🏃🏻‍➡️ E15.1 person running facing right: light skin tone
+1F3C3 1F3FB 200D 27A1                                  ; minimally-qualified # 🏃🏻‍➡ E15.1 person running facing right: light skin tone
+1F3C3 1F3FC 200D 27A1 FE0F                             ; fully-qualified     # 🏃🏼‍➡️ E15.1 person running facing right: medium-light skin tone
+1F3C3 1F3FC 200D 27A1                                  ; minimally-qualified # 🏃🏼‍➡ E15.1 person running facing right: medium-light skin tone
+1F3C3 1F3FD 200D 27A1 FE0F                             ; fully-qualified     # 🏃🏽‍➡️ E15.1 person running facing right: medium skin tone
+1F3C3 1F3FD 200D 27A1                                  ; minimally-qualified # 🏃🏽‍➡ E15.1 person running facing right: medium skin tone
+1F3C3 1F3FE 200D 27A1 FE0F                             ; fully-qualified     # 🏃🏾‍➡️ E15.1 person running facing right: medium-dark skin tone
+1F3C3 1F3FE 200D 27A1                                  ; minimally-qualified # 🏃🏾‍➡ E15.1 person running facing right: medium-dark skin tone
+1F3C3 1F3FF 200D 27A1 FE0F                             ; fully-qualified     # 🏃🏿‍➡️ E15.1 person running facing right: dark skin tone
+1F3C3 1F3FF 200D 27A1                                  ; minimally-qualified # 🏃🏿‍➡ E15.1 person running facing right: dark skin tone
+1F3C3 200D 2640 FE0F 200D 27A1 FE0F                    ; fully-qualified     # 🏃‍♀️‍➡️ E15.1 woman running facing right
+1F3C3 200D 2640 200D 27A1 FE0F                         ; minimally-qualified # 🏃‍♀‍➡️ E15.1 woman running facing right
+1F3C3 200D 2640 FE0F 200D 27A1                         ; minimally-qualified # 🏃‍♀️‍➡ E15.1 woman running facing right
+1F3C3 200D 2640 200D 27A1                              ; minimally-qualified # 🏃‍♀‍➡ E15.1 woman running facing right
+1F3C3 1F3FB 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏻‍♀️‍➡️ E15.1 woman running facing right: light skin tone
+1F3C3 1F3FB 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏻‍♀‍➡️ E15.1 woman running facing right: light skin tone
+1F3C3 1F3FB 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏻‍♀️‍➡ E15.1 woman running facing right: light skin tone
+1F3C3 1F3FB 200D 2640 200D 27A1                        ; minimally-qualified # 🏃🏻‍♀‍➡ E15.1 woman running facing right: light skin tone
+1F3C3 1F3FC 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏼‍♀️‍➡️ E15.1 woman running facing right: medium-light skin tone
+1F3C3 1F3FC 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏼‍♀‍➡️ E15.1 woman running facing right: medium-light skin tone
+1F3C3 1F3FC 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏼‍♀️‍➡ E15.1 woman running facing right: medium-light skin tone
+1F3C3 1F3FC 200D 2640 200D 27A1                        ; minimally-qualified # 🏃🏼‍♀‍➡ E15.1 woman running facing right: medium-light skin tone
+1F3C3 1F3FD 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏽‍♀️‍➡️ E15.1 woman running facing right: medium skin tone
+1F3C3 1F3FD 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏽‍♀‍➡️ E15.1 woman running facing right: medium skin tone
+1F3C3 1F3FD 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏽‍♀️‍➡ E15.1 woman running facing right: medium skin tone
+1F3C3 1F3FD 200D 2640 200D 27A1                        ; minimally-qualified # 🏃🏽‍♀‍➡ E15.1 woman running facing right: medium skin tone
+1F3C3 1F3FE 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏾‍♀️‍➡️ E15.1 woman running facing right: medium-dark skin tone
+1F3C3 1F3FE 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏾‍♀‍➡️ E15.1 woman running facing right: medium-dark skin tone
+1F3C3 1F3FE 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏾‍♀️‍➡ E15.1 woman running facing right: medium-dark skin tone
+1F3C3 1F3FE 200D 2640 200D 27A1                        ; minimally-qualified # 🏃🏾‍♀‍➡ E15.1 woman running facing right: medium-dark skin tone
+1F3C3 1F3FF 200D 2640 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏿‍♀️‍➡️ E15.1 woman running facing right: dark skin tone
+1F3C3 1F3FF 200D 2640 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏿‍♀‍➡️ E15.1 woman running facing right: dark skin tone
+1F3C3 1F3FF 200D 2640 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏿‍♀️‍➡ E15.1 woman running facing right: dark skin tone
+1F3C3 1F3FF 200D 2640 200D 27A1                        ; minimally-qualified # 🏃🏿‍♀‍➡ E15.1 woman running facing right: dark skin tone
+1F3C3 200D 2642 FE0F 200D 27A1 FE0F                    ; fully-qualified     # 🏃‍♂️‍➡️ E15.1 man running facing right
+1F3C3 200D 2642 200D 27A1 FE0F                         ; minimally-qualified # 🏃‍♂‍➡️ E15.1 man running facing right
+1F3C3 200D 2642 FE0F 200D 27A1                         ; minimally-qualified # 🏃‍♂️‍➡ E15.1 man running facing right
+1F3C3 200D 2642 200D 27A1                              ; minimally-qualified # 🏃‍♂‍➡ E15.1 man running facing right
+1F3C3 1F3FB 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏻‍♂️‍➡️ E15.1 man running facing right: light skin tone
+1F3C3 1F3FB 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏻‍♂‍➡️ E15.1 man running facing right: light skin tone
+1F3C3 1F3FB 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏻‍♂️‍➡ E15.1 man running facing right: light skin tone
+1F3C3 1F3FB 200D 2642 200D 27A1                        ; minimally-qualified # 🏃🏻‍♂‍➡ E15.1 man running facing right: light skin tone
+1F3C3 1F3FC 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏼‍♂️‍➡️ E15.1 man running facing right: medium-light skin tone
+1F3C3 1F3FC 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏼‍♂‍➡️ E15.1 man running facing right: medium-light skin tone
+1F3C3 1F3FC 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏼‍♂️‍➡ E15.1 man running facing right: medium-light skin tone
+1F3C3 1F3FC 200D 2642 200D 27A1                        ; minimally-qualified # 🏃🏼‍♂‍➡ E15.1 man running facing right: medium-light skin tone
+1F3C3 1F3FD 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏽‍♂️‍➡️ E15.1 man running facing right: medium skin tone
+1F3C3 1F3FD 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏽‍♂‍➡️ E15.1 man running facing right: medium skin tone
+1F3C3 1F3FD 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏽‍♂️‍➡ E15.1 man running facing right: medium skin tone
+1F3C3 1F3FD 200D 2642 200D 27A1                        ; minimally-qualified # 🏃🏽‍♂‍➡ E15.1 man running facing right: medium skin tone
+1F3C3 1F3FE 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏾‍♂️‍➡️ E15.1 man running facing right: medium-dark skin tone
+1F3C3 1F3FE 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏾‍♂‍➡️ E15.1 man running facing right: medium-dark skin tone
+1F3C3 1F3FE 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏾‍♂️‍➡ E15.1 man running facing right: medium-dark skin tone
+1F3C3 1F3FE 200D 2642 200D 27A1                        ; minimally-qualified # 🏃🏾‍♂‍➡ E15.1 man running facing right: medium-dark skin tone
+1F3C3 1F3FF 200D 2642 FE0F 200D 27A1 FE0F              ; fully-qualified     # 🏃🏿‍♂️‍➡️ E15.1 man running facing right: dark skin tone
+1F3C3 1F3FF 200D 2642 200D 27A1 FE0F                   ; minimally-qualified # 🏃🏿‍♂‍➡️ E15.1 man running facing right: dark skin tone
+1F3C3 1F3FF 200D 2642 FE0F 200D 27A1                   ; minimally-qualified # 🏃🏿‍♂️‍➡ E15.1 man running facing right: dark skin tone
+1F3C3 1F3FF 200D 2642 200D 27A1                        ; minimally-qualified # 🏃🏿‍♂‍➡ E15.1 man running facing right: dark skin tone
+1F9D1 200D 1FA70                                       ; fully-qualified     # 🧑‍🩰 E17.0 ballet dancer
+1F9D1 1F3FB 200D 1FA70                                 ; fully-qualified     # 🧑🏻‍🩰 E17.0 ballet dancer: light skin tone
+1F9D1 1F3FC 200D 1FA70                                 ; fully-qualified     # 🧑🏼‍🩰 E17.0 ballet dancer: medium-light skin tone
+1F9D1 1F3FD 200D 1FA70                                 ; fully-qualified     # 🧑🏽‍🩰 E17.0 ballet dancer: medium skin tone
+1F9D1 1F3FE 200D 1FA70                                 ; fully-qualified     # 🧑🏾‍🩰 E17.0 ballet dancer: medium-dark skin tone
+1F9D1 1F3FF 200D 1FA70                                 ; fully-qualified     # 🧑🏿‍🩰 E17.0 ballet dancer: dark skin tone
 1F483                                                  ; fully-qualified     # 💃 E0.6 woman dancing
 1F483 1F3FB                                            ; fully-qualified     # 💃🏻 E1.0 woman dancing: light skin tone
 1F483 1F3FC                                            ; fully-qualified     # 💃🏼 E1.0 woman dancing: medium-light skin tone
@@ -2229,10 +2535,95 @@
 1F574 1F3FE                                            ; fully-qualified     # 🕴🏾 E4.0 person in suit levitating: medium-dark skin tone
 1F574 1F3FF                                            ; fully-qualified     # 🕴🏿 E4.0 person in suit levitating: dark skin tone
 1F46F                                                  ; fully-qualified     # 👯 E0.6 people with bunny ears
+1F46F 1F3FB                                            ; fully-qualified     # 👯🏻 E17.0 people with bunny ears: light skin tone
+1F46F 1F3FC                                            ; fully-qualified     # 👯🏼 E17.0 people with bunny ears: medium-light skin tone
+1F46F 1F3FD                                            ; fully-qualified     # 👯🏽 E17.0 people with bunny ears: medium skin tone
+1F46F 1F3FE                                            ; fully-qualified     # 👯🏾 E17.0 people with bunny ears: medium-dark skin tone
+1F46F 1F3FF                                            ; fully-qualified     # 👯🏿 E17.0 people with bunny ears: dark skin tone
 1F46F 200D 2642 FE0F                                   ; fully-qualified     # 👯‍♂️ E4.0 men with bunny ears
 1F46F 200D 2642                                        ; minimally-qualified # 👯‍♂ E4.0 men with bunny ears
+1F46F 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 👯🏻‍♂️ E17.0 men with bunny ears: light skin tone
+1F46F 1F3FB 200D 2642                                  ; minimally-qualified # 👯🏻‍♂ E17.0 men with bunny ears: light skin tone
+1F46F 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 👯🏼‍♂️ E17.0 men with bunny ears: medium-light skin tone
+1F46F 1F3FC 200D 2642                                  ; minimally-qualified # 👯🏼‍♂ E17.0 men with bunny ears: medium-light skin tone
+1F46F 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 👯🏽‍♂️ E17.0 men with bunny ears: medium skin tone
+1F46F 1F3FD 200D 2642                                  ; minimally-qualified # 👯🏽‍♂ E17.0 men with bunny ears: medium skin tone
+1F46F 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 👯🏾‍♂️ E17.0 men with bunny ears: medium-dark skin tone
+1F46F 1F3FE 200D 2642                                  ; minimally-qualified # 👯🏾‍♂ E17.0 men with bunny ears: medium-dark skin tone
+1F46F 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 👯🏿‍♂️ E17.0 men with bunny ears: dark skin tone
+1F46F 1F3FF 200D 2642                                  ; minimally-qualified # 👯🏿‍♂ E17.0 men with bunny ears: dark skin tone
 1F46F 200D 2640 FE0F                                   ; fully-qualified     # 👯‍♀️ E4.0 women with bunny ears
 1F46F 200D 2640                                        ; minimally-qualified # 👯‍♀ E4.0 women with bunny ears
+1F46F 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 👯🏻‍♀️ E17.0 women with bunny ears: light skin tone
+1F46F 1F3FB 200D 2640                                  ; minimally-qualified # 👯🏻‍♀ E17.0 women with bunny ears: light skin tone
+1F46F 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 👯🏼‍♀️ E17.0 women with bunny ears: medium-light skin tone
+1F46F 1F3FC 200D 2640                                  ; minimally-qualified # 👯🏼‍♀ E17.0 women with bunny ears: medium-light skin tone
+1F46F 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 👯🏽‍♀️ E17.0 women with bunny ears: medium skin tone
+1F46F 1F3FD 200D 2640                                  ; minimally-qualified # 👯🏽‍♀ E17.0 women with bunny ears: medium skin tone
+1F46F 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 👯🏾‍♀️ E17.0 women with bunny ears: medium-dark skin tone
+1F46F 1F3FE 200D 2640                                  ; minimally-qualified # 👯🏾‍♀ E17.0 women with bunny ears: medium-dark skin tone
+1F46F 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 👯🏿‍♀️ E17.0 women with bunny ears: dark skin tone
+1F46F 1F3FF 200D 2640                                  ; minimally-qualified # 👯🏿‍♀ E17.0 women with bunny ears: dark skin tone
+1F9D1 1F3FB 200D 1F430 200D 1F9D1 1F3FC                ; fully-qualified     # 🧑🏻‍🐰‍🧑🏼 E17.0 people with bunny ears: light skin tone, medium-light skin tone
+1F9D1 1F3FB 200D 1F430 200D 1F9D1 1F3FD                ; fully-qualified     # 🧑🏻‍🐰‍🧑🏽 E17.0 people with bunny ears: light skin tone, medium skin tone
+1F9D1 1F3FB 200D 1F430 200D 1F9D1 1F3FE                ; fully-qualified     # 🧑🏻‍🐰‍🧑🏾 E17.0 people with bunny ears: light skin tone, medium-dark skin tone
+1F9D1 1F3FB 200D 1F430 200D 1F9D1 1F3FF                ; fully-qualified     # 🧑🏻‍🐰‍🧑🏿 E17.0 people with bunny ears: light skin tone, dark skin tone
+1F9D1 1F3FC 200D 1F430 200D 1F9D1 1F3FB                ; fully-qualified     # 🧑🏼‍🐰‍🧑🏻 E17.0 people with bunny ears: medium-light skin tone, light skin tone
+1F9D1 1F3FC 200D 1F430 200D 1F9D1 1F3FD                ; fully-qualified     # 🧑🏼‍🐰‍🧑🏽 E17.0 people with bunny ears: medium-light skin tone, medium skin tone
+1F9D1 1F3FC 200D 1F430 200D 1F9D1 1F3FE                ; fully-qualified     # 🧑🏼‍🐰‍🧑🏾 E17.0 people with bunny ears: medium-light skin tone, medium-dark skin tone
+1F9D1 1F3FC 200D 1F430 200D 1F9D1 1F3FF                ; fully-qualified     # 🧑🏼‍🐰‍🧑🏿 E17.0 people with bunny ears: medium-light skin tone, dark skin tone
+1F9D1 1F3FD 200D 1F430 200D 1F9D1 1F3FB                ; fully-qualified     # 🧑🏽‍🐰‍🧑🏻 E17.0 people with bunny ears: medium skin tone, light skin tone
+1F9D1 1F3FD 200D 1F430 200D 1F9D1 1F3FC                ; fully-qualified     # 🧑🏽‍🐰‍🧑🏼 E17.0 people with bunny ears: medium skin tone, medium-light skin tone
+1F9D1 1F3FD 200D 1F430 200D 1F9D1 1F3FE                ; fully-qualified     # 🧑🏽‍🐰‍🧑🏾 E17.0 people with bunny ears: medium skin tone, medium-dark skin tone
+1F9D1 1F3FD 200D 1F430 200D 1F9D1 1F3FF                ; fully-qualified     # 🧑🏽‍🐰‍🧑🏿 E17.0 people with bunny ears: medium skin tone, dark skin tone
+1F9D1 1F3FE 200D 1F430 200D 1F9D1 1F3FB                ; fully-qualified     # 🧑🏾‍🐰‍🧑🏻 E17.0 people with bunny ears: medium-dark skin tone, light skin tone
+1F9D1 1F3FE 200D 1F430 200D 1F9D1 1F3FC                ; fully-qualified     # 🧑🏾‍🐰‍🧑🏼 E17.0 people with bunny ears: medium-dark skin tone, medium-light skin tone
+1F9D1 1F3FE 200D 1F430 200D 1F9D1 1F3FD                ; fully-qualified     # 🧑🏾‍🐰‍🧑🏽 E17.0 people with bunny ears: medium-dark skin tone, medium skin tone
+1F9D1 1F3FE 200D 1F430 200D 1F9D1 1F3FF                ; fully-qualified     # 🧑🏾‍🐰‍🧑🏿 E17.0 people with bunny ears: medium-dark skin tone, dark skin tone
+1F9D1 1F3FF 200D 1F430 200D 1F9D1 1F3FB                ; fully-qualified     # 🧑🏿‍🐰‍🧑🏻 E17.0 people with bunny ears: dark skin tone, light skin tone
+1F9D1 1F3FF 200D 1F430 200D 1F9D1 1F3FC                ; fully-qualified     # 🧑🏿‍🐰‍🧑🏼 E17.0 people with bunny ears: dark skin tone, medium-light skin tone
+1F9D1 1F3FF 200D 1F430 200D 1F9D1 1F3FD                ; fully-qualified     # 🧑🏿‍🐰‍🧑🏽 E17.0 people with bunny ears: dark skin tone, medium skin tone
+1F9D1 1F3FF 200D 1F430 200D 1F9D1 1F3FE                ; fully-qualified     # 🧑🏿‍🐰‍🧑🏾 E17.0 people with bunny ears: dark skin tone, medium-dark skin tone
+1F468 1F3FB 200D 1F430 200D 1F468 1F3FC                ; fully-qualified     # 👨🏻‍🐰‍👨🏼 E17.0 men with bunny ears: light skin tone, medium-light skin tone
+1F468 1F3FB 200D 1F430 200D 1F468 1F3FD                ; fully-qualified     # 👨🏻‍🐰‍👨🏽 E17.0 men with bunny ears: light skin tone, medium skin tone
+1F468 1F3FB 200D 1F430 200D 1F468 1F3FE                ; fully-qualified     # 👨🏻‍🐰‍👨🏾 E17.0 men with bunny ears: light skin tone, medium-dark skin tone
+1F468 1F3FB 200D 1F430 200D 1F468 1F3FF                ; fully-qualified     # 👨🏻‍🐰‍👨🏿 E17.0 men with bunny ears: light skin tone, dark skin tone
+1F468 1F3FC 200D 1F430 200D 1F468 1F3FB                ; fully-qualified     # 👨🏼‍🐰‍👨🏻 E17.0 men with bunny ears: medium-light skin tone, light skin tone
+1F468 1F3FC 200D 1F430 200D 1F468 1F3FD                ; fully-qualified     # 👨🏼‍🐰‍👨🏽 E17.0 men with bunny ears: medium-light skin tone, medium skin tone
+1F468 1F3FC 200D 1F430 200D 1F468 1F3FE                ; fully-qualified     # 👨🏼‍🐰‍👨🏾 E17.0 men with bunny ears: medium-light skin tone, medium-dark skin tone
+1F468 1F3FC 200D 1F430 200D 1F468 1F3FF                ; fully-qualified     # 👨🏼‍🐰‍👨🏿 E17.0 men with bunny ears: medium-light skin tone, dark skin tone
+1F468 1F3FD 200D 1F430 200D 1F468 1F3FB                ; fully-qualified     # 👨🏽‍🐰‍👨🏻 E17.0 men with bunny ears: medium skin tone, light skin tone
+1F468 1F3FD 200D 1F430 200D 1F468 1F3FC                ; fully-qualified     # 👨🏽‍🐰‍👨🏼 E17.0 men with bunny ears: medium skin tone, medium-light skin tone
+1F468 1F3FD 200D 1F430 200D 1F468 1F3FE                ; fully-qualified     # 👨🏽‍🐰‍👨🏾 E17.0 men with bunny ears: medium skin tone, medium-dark skin tone
+1F468 1F3FD 200D 1F430 200D 1F468 1F3FF                ; fully-qualified     # 👨🏽‍🐰‍👨🏿 E17.0 men with bunny ears: medium skin tone, dark skin tone
+1F468 1F3FE 200D 1F430 200D 1F468 1F3FB                ; fully-qualified     # 👨🏾‍🐰‍👨🏻 E17.0 men with bunny ears: medium-dark skin tone, light skin tone
+1F468 1F3FE 200D 1F430 200D 1F468 1F3FC                ; fully-qualified     # 👨🏾‍🐰‍👨🏼 E17.0 men with bunny ears: medium-dark skin tone, medium-light skin tone
+1F468 1F3FE 200D 1F430 200D 1F468 1F3FD                ; fully-qualified     # 👨🏾‍🐰‍👨🏽 E17.0 men with bunny ears: medium-dark skin tone, medium skin tone
+1F468 1F3FE 200D 1F430 200D 1F468 1F3FF                ; fully-qualified     # 👨🏾‍🐰‍👨🏿 E17.0 men with bunny ears: medium-dark skin tone, dark skin tone
+1F468 1F3FF 200D 1F430 200D 1F468 1F3FB                ; fully-qualified     # 👨🏿‍🐰‍👨🏻 E17.0 men with bunny ears: dark skin tone, light skin tone
+1F468 1F3FF 200D 1F430 200D 1F468 1F3FC                ; fully-qualified     # 👨🏿‍🐰‍👨🏼 E17.0 men with bunny ears: dark skin tone, medium-light skin tone
+1F468 1F3FF 200D 1F430 200D 1F468 1F3FD                ; fully-qualified     # 👨🏿‍🐰‍👨🏽 E17.0 men with bunny ears: dark skin tone, medium skin tone
+1F468 1F3FF 200D 1F430 200D 1F468 1F3FE                ; fully-qualified     # 👨🏿‍🐰‍👨🏾 E17.0 men with bunny ears: dark skin tone, medium-dark skin tone
+1F469 1F3FB 200D 1F430 200D 1F469 1F3FC                ; fully-qualified     # 👩🏻‍🐰‍👩🏼 E17.0 women with bunny ears: light skin tone, medium-light skin tone
+1F469 1F3FB 200D 1F430 200D 1F469 1F3FD                ; fully-qualified     # 👩🏻‍🐰‍👩🏽 E17.0 women with bunny ears: light skin tone, medium skin tone
+1F469 1F3FB 200D 1F430 200D 1F469 1F3FE                ; fully-qualified     # 👩🏻‍🐰‍👩🏾 E17.0 women with bunny ears: light skin tone, medium-dark skin tone
+1F469 1F3FB 200D 1F430 200D 1F469 1F3FF                ; fully-qualified     # 👩🏻‍🐰‍👩🏿 E17.0 women with bunny ears: light skin tone, dark skin tone
+1F469 1F3FC 200D 1F430 200D 1F469 1F3FB                ; fully-qualified     # 👩🏼‍🐰‍👩🏻 E17.0 women with bunny ears: medium-light skin tone, light skin tone
+1F469 1F3FC 200D 1F430 200D 1F469 1F3FD                ; fully-qualified     # 👩🏼‍🐰‍👩🏽 E17.0 women with bunny ears: medium-light skin tone, medium skin tone
+1F469 1F3FC 200D 1F430 200D 1F469 1F3FE                ; fully-qualified     # 👩🏼‍🐰‍👩🏾 E17.0 women with bunny ears: medium-light skin tone, medium-dark skin tone
+1F469 1F3FC 200D 1F430 200D 1F469 1F3FF                ; fully-qualified     # 👩🏼‍🐰‍👩🏿 E17.0 women with bunny ears: medium-light skin tone, dark skin tone
+1F469 1F3FD 200D 1F430 200D 1F469 1F3FB                ; fully-qualified     # 👩🏽‍🐰‍👩🏻 E17.0 women with bunny ears: medium skin tone, light skin tone
+1F469 1F3FD 200D 1F430 200D 1F469 1F3FC                ; fully-qualified     # 👩🏽‍🐰‍👩🏼 E17.0 women with bunny ears: medium skin tone, medium-light skin tone
+1F469 1F3FD 200D 1F430 200D 1F469 1F3FE                ; fully-qualified     # 👩🏽‍🐰‍👩🏾 E17.0 women with bunny ears: medium skin tone, medium-dark skin tone
+1F469 1F3FD 200D 1F430 200D 1F469 1F3FF                ; fully-qualified     # 👩🏽‍🐰‍👩🏿 E17.0 women with bunny ears: medium skin tone, dark skin tone
+1F469 1F3FE 200D 1F430 200D 1F469 1F3FB                ; fully-qualified     # 👩🏾‍🐰‍👩🏻 E17.0 women with bunny ears: medium-dark skin tone, light skin tone
+1F469 1F3FE 200D 1F430 200D 1F469 1F3FC                ; fully-qualified     # 👩🏾‍🐰‍👩🏼 E17.0 women with bunny ears: medium-dark skin tone, medium-light skin tone
+1F469 1F3FE 200D 1F430 200D 1F469 1F3FD                ; fully-qualified     # 👩🏾‍🐰‍👩🏽 E17.0 women with bunny ears: medium-dark skin tone, medium skin tone
+1F469 1F3FE 200D 1F430 200D 1F469 1F3FF                ; fully-qualified     # 👩🏾‍🐰‍👩🏿 E17.0 women with bunny ears: medium-dark skin tone, dark skin tone
+1F469 1F3FF 200D 1F430 200D 1F469 1F3FB                ; fully-qualified     # 👩🏿‍🐰‍👩🏻 E17.0 women with bunny ears: dark skin tone, light skin tone
+1F469 1F3FF 200D 1F430 200D 1F469 1F3FC                ; fully-qualified     # 👩🏿‍🐰‍👩🏼 E17.0 women with bunny ears: dark skin tone, medium-light skin tone
+1F469 1F3FF 200D 1F430 200D 1F469 1F3FD                ; fully-qualified     # 👩🏿‍🐰‍👩🏽 E17.0 women with bunny ears: dark skin tone, medium skin tone
+1F469 1F3FF 200D 1F430 200D 1F469 1F3FE                ; fully-qualified     # 👩🏿‍🐰‍👩🏾 E17.0 women with bunny ears: dark skin tone, medium-dark skin tone
 1F9D6                                                  ; fully-qualified     # 🧖 E5.0 person in steamy room
 1F9D6 1F3FB                                            ; fully-qualified     # 🧖🏻 E5.0 person in steamy room: light skin tone
 1F9D6 1F3FC                                            ; fully-qualified     # 🧖🏼 E5.0 person in steamy room: medium-light skin tone
@@ -2596,10 +2987,95 @@
 1F938 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🤸🏿‍♀️ E4.0 woman cartwheeling: dark skin tone
 1F938 1F3FF 200D 2640                                  ; minimally-qualified # 🤸🏿‍♀ E4.0 woman cartwheeling: dark skin tone
 1F93C                                                  ; fully-qualified     # 🤼 E3.0 people wrestling
+1F93C 1F3FB                                            ; fully-qualified     # 🤼🏻 E17.0 people wrestling: light skin tone
+1F93C 1F3FC                                            ; fully-qualified     # 🤼🏼 E17.0 people wrestling: medium-light skin tone
+1F93C 1F3FD                                            ; fully-qualified     # 🤼🏽 E17.0 people wrestling: medium skin tone
+1F93C 1F3FE                                            ; fully-qualified     # 🤼🏾 E17.0 people wrestling: medium-dark skin tone
+1F93C 1F3FF                                            ; fully-qualified     # 🤼🏿 E17.0 people wrestling: dark skin tone
 1F93C 200D 2642 FE0F                                   ; fully-qualified     # 🤼‍♂️ E4.0 men wrestling
 1F93C 200D 2642                                        ; minimally-qualified # 🤼‍♂ E4.0 men wrestling
+1F93C 1F3FB 200D 2642 FE0F                             ; fully-qualified     # 🤼🏻‍♂️ E17.0 men wrestling: light skin tone
+1F93C 1F3FB 200D 2642                                  ; minimally-qualified # 🤼🏻‍♂ E17.0 men wrestling: light skin tone
+1F93C 1F3FC 200D 2642 FE0F                             ; fully-qualified     # 🤼🏼‍♂️ E17.0 men wrestling: medium-light skin tone
+1F93C 1F3FC 200D 2642                                  ; minimally-qualified # 🤼🏼‍♂ E17.0 men wrestling: medium-light skin tone
+1F93C 1F3FD 200D 2642 FE0F                             ; fully-qualified     # 🤼🏽‍♂️ E17.0 men wrestling: medium skin tone
+1F93C 1F3FD 200D 2642                                  ; minimally-qualified # 🤼🏽‍♂ E17.0 men wrestling: medium skin tone
+1F93C 1F3FE 200D 2642 FE0F                             ; fully-qualified     # 🤼🏾‍♂️ E17.0 men wrestling: medium-dark skin tone
+1F93C 1F3FE 200D 2642                                  ; minimally-qualified # 🤼🏾‍♂ E17.0 men wrestling: medium-dark skin tone
+1F93C 1F3FF 200D 2642 FE0F                             ; fully-qualified     # 🤼🏿‍♂️ E17.0 men wrestling: dark skin tone
+1F93C 1F3FF 200D 2642                                  ; minimally-qualified # 🤼🏿‍♂ E17.0 men wrestling: dark skin tone
 1F93C 200D 2640 FE0F                                   ; fully-qualified     # 🤼‍♀️ E4.0 women wrestling
 1F93C 200D 2640                                        ; minimally-qualified # 🤼‍♀ E4.0 women wrestling
+1F93C 1F3FB 200D 2640 FE0F                             ; fully-qualified     # 🤼🏻‍♀️ E17.0 women wrestling: light skin tone
+1F93C 1F3FB 200D 2640                                  ; minimally-qualified # 🤼🏻‍♀ E17.0 women wrestling: light skin tone
+1F93C 1F3FC 200D 2640 FE0F                             ; fully-qualified     # 🤼🏼‍♀️ E17.0 women wrestling: medium-light skin tone
+1F93C 1F3FC 200D 2640                                  ; minimally-qualified # 🤼🏼‍♀ E17.0 women wrestling: medium-light skin tone
+1F93C 1F3FD 200D 2640 FE0F                             ; fully-qualified     # 🤼🏽‍♀️ E17.0 women wrestling: medium skin tone
+1F93C 1F3FD 200D 2640                                  ; minimally-qualified # 🤼🏽‍♀ E17.0 women wrestling: medium skin tone
+1F93C 1F3FE 200D 2640 FE0F                             ; fully-qualified     # 🤼🏾‍♀️ E17.0 women wrestling: medium-dark skin tone
+1F93C 1F3FE 200D 2640                                  ; minimally-qualified # 🤼🏾‍♀ E17.0 women wrestling: medium-dark skin tone
+1F93C 1F3FF 200D 2640 FE0F                             ; fully-qualified     # 🤼🏿‍♀️ E17.0 women wrestling: dark skin tone
+1F93C 1F3FF 200D 2640                                  ; minimally-qualified # 🤼🏿‍♀ E17.0 women wrestling: dark skin tone
+1F9D1 1F3FB 200D 1FAEF 200D 1F9D1 1F3FC                ; fully-qualified     # 🧑🏻‍🫯‍🧑🏼 E17.0 people wrestling: light skin tone, medium-light skin tone
+1F9D1 1F3FB 200D 1FAEF 200D 1F9D1 1F3FD                ; fully-qualified     # 🧑🏻‍🫯‍🧑🏽 E17.0 people wrestling: light skin tone, medium skin tone
+1F9D1 1F3FB 200D 1FAEF 200D 1F9D1 1F3FE                ; fully-qualified     # 🧑🏻‍🫯‍🧑🏾 E17.0 people wrestling: light skin tone, medium-dark skin tone
+1F9D1 1F3FB 200D 1FAEF 200D 1F9D1 1F3FF                ; fully-qualified     # 🧑🏻‍🫯‍🧑🏿 E17.0 people wrestling: light skin tone, dark skin tone
+1F9D1 1F3FC 200D 1FAEF 200D 1F9D1 1F3FB                ; fully-qualified     # 🧑🏼‍🫯‍🧑🏻 E17.0 people wrestling: medium-light skin tone, light skin tone
+1F9D1 1F3FC 200D 1FAEF 200D 1F9D1 1F3FD                ; fully-qualified     # 🧑🏼‍🫯‍🧑🏽 E17.0 people wrestling: medium-light skin tone, medium skin tone
+1F9D1 1F3FC 200D 1FAEF 200D 1F9D1 1F3FE                ; fully-qualified     # 🧑🏼‍🫯‍🧑🏾 E17.0 people wrestling: medium-light skin tone, medium-dark skin tone
+1F9D1 1F3FC 200D 1FAEF 200D 1F9D1 1F3FF                ; fully-qualified     # 🧑🏼‍🫯‍🧑🏿 E17.0 people wrestling: medium-light skin tone, dark skin tone
+1F9D1 1F3FD 200D 1FAEF 200D 1F9D1 1F3FB                ; fully-qualified     # 🧑🏽‍🫯‍🧑🏻 E17.0 people wrestling: medium skin tone, light skin tone
+1F9D1 1F3FD 200D 1FAEF 200D 1F9D1 1F3FC                ; fully-qualified     # 🧑🏽‍🫯‍🧑🏼 E17.0 people wrestling: medium skin tone, medium-light skin tone
+1F9D1 1F3FD 200D 1FAEF 200D 1F9D1 1F3FE                ; fully-qualified     # 🧑🏽‍🫯‍🧑🏾 E17.0 people wrestling: medium skin tone, medium-dark skin tone
+1F9D1 1F3FD 200D 1FAEF 200D 1F9D1 1F3FF                ; fully-qualified     # 🧑🏽‍🫯‍🧑🏿 E17.0 people wrestling: medium skin tone, dark skin tone
+1F9D1 1F3FE 200D 1FAEF 200D 1F9D1 1F3FB                ; fully-qualified     # 🧑🏾‍🫯‍🧑🏻 E17.0 people wrestling: medium-dark skin tone, light skin tone
+1F9D1 1F3FE 200D 1FAEF 200D 1F9D1 1F3FC                ; fully-qualified     # 🧑🏾‍🫯‍🧑🏼 E17.0 people wrestling: medium-dark skin tone, medium-light skin tone
+1F9D1 1F3FE 200D 1FAEF 200D 1F9D1 1F3FD                ; fully-qualified     # 🧑🏾‍🫯‍🧑🏽 E17.0 people wrestling: medium-dark skin tone, medium skin tone
+1F9D1 1F3FE 200D 1FAEF 200D 1F9D1 1F3FF                ; fully-qualified     # 🧑🏾‍🫯‍🧑🏿 E17.0 people wrestling: medium-dark skin tone, dark skin tone
+1F9D1 1F3FF 200D 1FAEF 200D 1F9D1 1F3FB                ; fully-qualified     # 🧑🏿‍🫯‍🧑🏻 E17.0 people wrestling: dark skin tone, light skin tone
+1F9D1 1F3FF 200D 1FAEF 200D 1F9D1 1F3FC                ; fully-qualified     # 🧑🏿‍🫯‍🧑🏼 E17.0 people wrestling: dark skin tone, medium-light skin tone
+1F9D1 1F3FF 200D 1FAEF 200D 1F9D1 1F3FD                ; fully-qualified     # 🧑🏿‍🫯‍🧑🏽 E17.0 people wrestling: dark skin tone, medium skin tone
+1F9D1 1F3FF 200D 1FAEF 200D 1F9D1 1F3FE                ; fully-qualified     # 🧑🏿‍🫯‍🧑🏾 E17.0 people wrestling: dark skin tone, medium-dark skin tone
+1F468 1F3FB 200D 1FAEF 200D 1F468 1F3FC                ; fully-qualified     # 👨🏻‍🫯‍👨🏼 E17.0 men wrestling: light skin tone, medium-light skin tone
+1F468 1F3FB 200D 1FAEF 200D 1F468 1F3FD                ; fully-qualified     # 👨🏻‍🫯‍👨🏽 E17.0 men wrestling: light skin tone, medium skin tone
+1F468 1F3FB 200D 1FAEF 200D 1F468 1F3FE                ; fully-qualified     # 👨🏻‍🫯‍👨🏾 E17.0 men wrestling: light skin tone, medium-dark skin tone
+1F468 1F3FB 200D 1FAEF 200D 1F468 1F3FF                ; fully-qualified     # 👨🏻‍🫯‍👨🏿 E17.0 men wrestling: light skin tone, dark skin tone
+1F468 1F3FC 200D 1FAEF 200D 1F468 1F3FB                ; fully-qualified     # 👨🏼‍🫯‍👨🏻 E17.0 men wrestling: medium-light skin tone, light skin tone
+1F468 1F3FC 200D 1FAEF 200D 1F468 1F3FD                ; fully-qualified     # 👨🏼‍🫯‍👨🏽 E17.0 men wrestling: medium-light skin tone, medium skin tone
+1F468 1F3FC 200D 1FAEF 200D 1F468 1F3FE                ; fully-qualified     # 👨🏼‍🫯‍👨🏾 E17.0 men wrestling: medium-light skin tone, medium-dark skin tone
+1F468 1F3FC 200D 1FAEF 200D 1F468 1F3FF                ; fully-qualified     # 👨🏼‍🫯‍👨🏿 E17.0 men wrestling: medium-light skin tone, dark skin tone
+1F468 1F3FD 200D 1FAEF 200D 1F468 1F3FB                ; fully-qualified     # 👨🏽‍🫯‍👨🏻 E17.0 men wrestling: medium skin tone, light skin tone
+1F468 1F3FD 200D 1FAEF 200D 1F468 1F3FC                ; fully-qualified     # 👨🏽‍🫯‍👨🏼 E17.0 men wrestling: medium skin tone, medium-light skin tone
+1F468 1F3FD 200D 1FAEF 200D 1F468 1F3FE                ; fully-qualified     # 👨🏽‍🫯‍👨🏾 E17.0 men wrestling: medium skin tone, medium-dark skin tone
+1F468 1F3FD 200D 1FAEF 200D 1F468 1F3FF                ; fully-qualified     # 👨🏽‍🫯‍👨🏿 E17.0 men wrestling: medium skin tone, dark skin tone
+1F468 1F3FE 200D 1FAEF 200D 1F468 1F3FB                ; fully-qualified     # 👨🏾‍🫯‍👨🏻 E17.0 men wrestling: medium-dark skin tone, light skin tone
+1F468 1F3FE 200D 1FAEF 200D 1F468 1F3FC                ; fully-qualified     # 👨🏾‍🫯‍👨🏼 E17.0 men wrestling: medium-dark skin tone, medium-light skin tone
+1F468 1F3FE 200D 1FAEF 200D 1F468 1F3FD                ; fully-qualified     # 👨🏾‍🫯‍👨🏽 E17.0 men wrestling: medium-dark skin tone, medium skin tone
+1F468 1F3FE 200D 1FAEF 200D 1F468 1F3FF                ; fully-qualified     # 👨🏾‍🫯‍👨🏿 E17.0 men wrestling: medium-dark skin tone, dark skin tone
+1F468 1F3FF 200D 1FAEF 200D 1F468 1F3FB                ; fully-qualified     # 👨🏿‍🫯‍👨🏻 E17.0 men wrestling: dark skin tone, light skin tone
+1F468 1F3FF 200D 1FAEF 200D 1F468 1F3FC                ; fully-qualified     # 👨🏿‍🫯‍👨🏼 E17.0 men wrestling: dark skin tone, medium-light skin tone
+1F468 1F3FF 200D 1FAEF 200D 1F468 1F3FD                ; fully-qualified     # 👨🏿‍🫯‍👨🏽 E17.0 men wrestling: dark skin tone, medium skin tone
+1F468 1F3FF 200D 1FAEF 200D 1F468 1F3FE                ; fully-qualified     # 👨🏿‍🫯‍👨🏾 E17.0 men wrestling: dark skin tone, medium-dark skin tone
+1F469 1F3FB 200D 1FAEF 200D 1F469 1F3FC                ; fully-qualified     # 👩🏻‍🫯‍👩🏼 E17.0 women wrestling: light skin tone, medium-light skin tone
+1F469 1F3FB 200D 1FAEF 200D 1F469 1F3FD                ; fully-qualified     # 👩🏻‍🫯‍👩🏽 E17.0 women wrestling: light skin tone, medium skin tone
+1F469 1F3FB 200D 1FAEF 200D 1F469 1F3FE                ; fully-qualified     # 👩🏻‍🫯‍👩🏾 E17.0 women wrestling: light skin tone, medium-dark skin tone
+1F469 1F3FB 200D 1FAEF 200D 1F469 1F3FF                ; fully-qualified     # 👩🏻‍🫯‍👩🏿 E17.0 women wrestling: light skin tone, dark skin tone
+1F469 1F3FC 200D 1FAEF 200D 1F469 1F3FB                ; fully-qualified     # 👩🏼‍🫯‍👩🏻 E17.0 women wrestling: medium-light skin tone, light skin tone
+1F469 1F3FC 200D 1FAEF 200D 1F469 1F3FD                ; fully-qualified     # 👩🏼‍🫯‍👩🏽 E17.0 women wrestling: medium-light skin tone, medium skin tone
+1F469 1F3FC 200D 1FAEF 200D 1F469 1F3FE                ; fully-qualified     # 👩🏼‍🫯‍👩🏾 E17.0 women wrestling: medium-light skin tone, medium-dark skin tone
+1F469 1F3FC 200D 1FAEF 200D 1F469 1F3FF                ; fully-qualified     # 👩🏼‍🫯‍👩🏿 E17.0 women wrestling: medium-light skin tone, dark skin tone
+1F469 1F3FD 200D 1FAEF 200D 1F469 1F3FB                ; fully-qualified     # 👩🏽‍🫯‍👩🏻 E17.0 women wrestling: medium skin tone, light skin tone
+1F469 1F3FD 200D 1FAEF 200D 1F469 1F3FC                ; fully-qualified     # 👩🏽‍🫯‍👩🏼 E17.0 women wrestling: medium skin tone, medium-light skin tone
+1F469 1F3FD 200D 1FAEF 200D 1F469 1F3FE                ; fully-qualified     # 👩🏽‍🫯‍👩🏾 E17.0 women wrestling: medium skin tone, medium-dark skin tone
+1F469 1F3FD 200D 1FAEF 200D 1F469 1F3FF                ; fully-qualified     # 👩🏽‍🫯‍👩🏿 E17.0 women wrestling: medium skin tone, dark skin tone
+1F469 1F3FE 200D 1FAEF 200D 1F469 1F3FB                ; fully-qualified     # 👩🏾‍🫯‍👩🏻 E17.0 women wrestling: medium-dark skin tone, light skin tone
+1F469 1F3FE 200D 1FAEF 200D 1F469 1F3FC                ; fully-qualified     # 👩🏾‍🫯‍👩🏼 E17.0 women wrestling: medium-dark skin tone, medium-light skin tone
+1F469 1F3FE 200D 1FAEF 200D 1F469 1F3FD                ; fully-qualified     # 👩🏾‍🫯‍👩🏽 E17.0 women wrestling: medium-dark skin tone, medium skin tone
+1F469 1F3FE 200D 1FAEF 200D 1F469 1F3FF                ; fully-qualified     # 👩🏾‍🫯‍👩🏿 E17.0 women wrestling: medium-dark skin tone, dark skin tone
+1F469 1F3FF 200D 1FAEF 200D 1F469 1F3FB                ; fully-qualified     # 👩🏿‍🫯‍👩🏻 E17.0 women wrestling: dark skin tone, light skin tone
+1F469 1F3FF 200D 1FAEF 200D 1F469 1F3FC                ; fully-qualified     # 👩🏿‍🫯‍👩🏼 E17.0 women wrestling: dark skin tone, medium-light skin tone
+1F469 1F3FF 200D 1FAEF 200D 1F469 1F3FD                ; fully-qualified     # 👩🏿‍🫯‍👩🏽 E17.0 women wrestling: dark skin tone, medium skin tone
+1F469 1F3FF 200D 1FAEF 200D 1F469 1F3FE                ; fully-qualified     # 👩🏿‍🫯‍👩🏾 E17.0 women wrestling: dark skin tone, medium-dark skin tone
 1F93D                                                  ; fully-qualified     # 🤽 E3.0 person playing water polo
 1F93D 1F3FB                                            ; fully-qualified     # 🤽🏻 E3.0 person playing water polo: light skin tone
 1F93D 1F3FC                                            ; fully-qualified     # 🤽🏼 E3.0 person playing water polo: medium-light skin tone
@@ -3244,7 +3720,6 @@
 1F469 1F3FF 200D 2764 200D 1F469 1F3FE                 ; minimally-qualified # 👩🏿‍❤‍👩🏾 E13.1 couple with heart: woman, woman, dark skin tone, medium-dark skin tone
 1F469 1F3FF 200D 2764 FE0F 200D 1F469 1F3FF            ; fully-qualified     # 👩🏿‍❤️‍👩🏿 E13.1 couple with heart: woman, woman, dark skin tone
 1F469 1F3FF 200D 2764 200D 1F469 1F3FF                 ; minimally-qualified # 👩🏿‍❤‍👩🏿 E13.1 couple with heart: woman, woman, dark skin tone
-1F46A                                                  ; fully-qualified     # 👪 E0.6 family
 1F468 200D 1F469 200D 1F466                            ; fully-qualified     # 👨‍👩‍👦 E2.0 family: man, woman, boy
 1F468 200D 1F469 200D 1F467                            ; fully-qualified     # 👨‍👩‍👧 E2.0 family: man, woman, girl
 1F468 200D 1F469 200D 1F467 200D 1F466                 ; fully-qualified     # 👨‍👩‍👧‍👦 E2.0 family: man, woman, girl, boy
@@ -3277,10 +3752,16 @@
 1F464                                                  ; fully-qualified     # 👤 E0.6 bust in silhouette
 1F465                                                  ; fully-qualified     # 👥 E1.0 busts in silhouette
 1FAC2                                                  ; fully-qualified     # 🫂 E13.0 people hugging
+1F46A                                                  ; fully-qualified     # 👪 E0.6 family
+1F9D1 200D 1F9D1 200D 1F9D2                            ; fully-qualified     # 🧑‍🧑‍🧒 E15.1 family: adult, adult, child
+1F9D1 200D 1F9D1 200D 1F9D2 200D 1F9D2                 ; fully-qualified     # 🧑‍🧑‍🧒‍🧒 E15.1 family: adult, adult, child, child
+1F9D1 200D 1F9D2                                       ; fully-qualified     # 🧑‍🧒 E15.1 family: adult, child
+1F9D1 200D 1F9D2 200D 1F9D2                            ; fully-qualified     # 🧑‍🧒‍🧒 E15.1 family: adult, child, child
 1F463                                                  ; fully-qualified     # 👣 E0.6 footprints
+1FAC6                                                  ; fully-qualified     # 🫆 E16.0 fingerprint
 
-# People & Body subtotal:		2998
-# People & Body subtotal:		508	w/o modifiers
+# People & Body subtotal:		3468
+# People & Body subtotal:		563	w/o modifiers
 
 # group: Component
 
@@ -3395,6 +3876,7 @@
 1FABD                                                  ; fully-qualified     # 🪽 E15.0 wing
 1F426 200D 2B1B                                        ; fully-qualified     # 🐦‍⬛ E15.0 black bird
 1FABF                                                  ; fully-qualified     # 🪿 E15.0 goose
+1F426 200D 1F525                                       ; fully-qualified     # 🐦‍🔥 E15.1 phoenix
 
 # subgroup: animal-amphibian
 1F438                                                  ; fully-qualified     # 🐸 E0.6 frog
@@ -3413,6 +3895,7 @@
 1F433                                                  ; fully-qualified     # 🐳 E0.6 spouting whale
 1F40B                                                  ; fully-qualified     # 🐋 E1.0 whale
 1F42C                                                  ; fully-qualified     # 🐬 E0.6 dolphin
+1FACD                                                  ; fully-qualified     # 🫍 E17.0 orca
 1F9AD                                                  ; fully-qualified     # 🦭 E13.0 seal
 1F41F                                                  ; fully-qualified     # 🐟 E0.6 fish
 1F420                                                  ; fully-qualified     # 🐠 E0.6 tropical fish
@@ -3422,6 +3905,11 @@
 1F41A                                                  ; fully-qualified     # 🐚 E0.6 spiral shell
 1FAB8                                                  ; fully-qualified     # 🪸 E14.0 coral
 1FABC                                                  ; fully-qualified     # 🪼 E15.0 jellyfish
+1F980                                                  ; fully-qualified     # 🦀 E1.0 crab
+1F99E                                                  ; fully-qualified     # 🦞 E11.0 lobster
+1F990                                                  ; fully-qualified     # 🦐 E3.0 shrimp
+1F991                                                  ; fully-qualified     # 🦑 E3.0 squid
+1F9AA                                                  ; fully-qualified     # 🦪 E12.0 oyster
 
 # subgroup: animal-bug
 1F40C                                                  ; fully-qualified     # 🐌 E0.6 snail
@@ -3476,9 +3964,10 @@
 1FAB9                                                  ; fully-qualified     # 🪹 E14.0 empty nest
 1FABA                                                  ; fully-qualified     # 🪺 E14.0 nest with eggs
 1F344                                                  ; fully-qualified     # 🍄 E0.6 mushroom
+1FABE                                                  ; fully-qualified     # 🪾 E16.0 leafless tree
 
-# Animals & Nature subtotal:		159
-# Animals & Nature subtotal:		159	w/o modifiers
+# Animals & Nature subtotal:		167
+# Animals & Nature subtotal:		167	w/o modifiers
 
 # group: Food & Drink
 
@@ -3488,6 +3977,7 @@
 1F349                                                  ; fully-qualified     # 🍉 E0.6 watermelon
 1F34A                                                  ; fully-qualified     # 🍊 E0.6 tangerine
 1F34B                                                  ; fully-qualified     # 🍋 E1.0 lemon
+1F34B 200D 1F7E9                                       ; fully-qualified     # 🍋‍🟩 E15.1 lime
 1F34C                                                  ; fully-qualified     # 🍌 E0.6 banana
 1F34D                                                  ; fully-qualified     # 🍍 E0.6 pineapple
 1F96D                                                  ; fully-qualified     # 🥭 E11.0 mango
@@ -3522,6 +4012,8 @@
 1F330                                                  ; fully-qualified     # 🌰 E0.6 chestnut
 1FADA                                                  ; fully-qualified     # 🫚 E15.0 ginger root
 1FADB                                                  ; fully-qualified     # 🫛 E15.0 pea pod
+1F344 200D 1F7EB                                       ; fully-qualified     # 🍄‍🟫 E15.1 brown mushroom
+1FADC                                                  ; fully-qualified     # 🫜 E16.0 root vegetable
 
 # subgroup: food-prepared
 1F35E                                                  ; fully-qualified     # 🍞 E0.6 bread
@@ -3578,13 +4070,6 @@
 1F960                                                  ; fully-qualified     # 🥠 E5.0 fortune cookie
 1F961                                                  ; fully-qualified     # 🥡 E5.0 takeout box
 
-# subgroup: food-marine
-1F980                                                  ; fully-qualified     # 🦀 E1.0 crab
-1F99E                                                  ; fully-qualified     # 🦞 E11.0 lobster
-1F990                                                  ; fully-qualified     # 🦐 E3.0 shrimp
-1F991                                                  ; fully-qualified     # 🦑 E3.0 squid
-1F9AA                                                  ; fully-qualified     # 🦪 E12.0 oyster
-
 # subgroup: food-sweet
 1F366                                                  ; fully-qualified     # 🍦 E0.6 soft ice cream
 1F367                                                  ; fully-qualified     # 🍧 E0.6 shaved ice
@@ -3633,8 +4118,8 @@
 1FAD9                                                  ; fully-qualified     # 🫙 E14.0 jar
 1F3FA                                                  ; fully-qualified     # 🏺 E1.0 amphora
 
-# Food & Drink subtotal:		135
-# Food & Drink subtotal:		135	w/o modifiers
+# Food & Drink subtotal:		133
+# Food & Drink subtotal:		133	w/o modifiers
 
 # group: Travel & Places
 
@@ -3653,6 +4138,7 @@
 1F3D4                                                  ; unqualified         # 🏔 E0.7 snow-capped mountain
 26F0 FE0F                                              ; fully-qualified     # ⛰️ E0.7 mountain
 26F0                                                   ; unqualified         # ⛰ E0.7 mountain
+1F6D8                                                  ; fully-qualified     # 🛘 E17.0 landslide
 1F30B                                                  ; fully-qualified     # 🌋 E0.6 volcano
 1F5FB                                                  ; fully-qualified     # 🗻 E0.6 mount fuji
 1F3D5 FE0F                                             ; fully-qualified     # 🏕️ E0.7 camping
@@ -3927,8 +4413,8 @@
 1F4A7                                                  ; fully-qualified     # 💧 E0.6 droplet
 1F30A                                                  ; fully-qualified     # 🌊 E0.6 water wave
 
-# Travel & Places subtotal:		267
-# Travel & Places subtotal:		267	w/o modifiers
+# Travel & Places subtotal:		268
+# Travel & Places subtotal:		268	w/o modifiers
 
 # group: Activities
 
@@ -4122,16 +4608,18 @@
 
 # subgroup: musical-instrument
 1F3B7                                                  ; fully-qualified     # 🎷 E0.6 saxophone
+1F3BA                                                  ; fully-qualified     # 🎺 E0.6 trumpet
+1FA8A                                                  ; fully-qualified     # 🪊 E17.0 trombone
 1FA97                                                  ; fully-qualified     # 🪗 E13.0 accordion
 1F3B8                                                  ; fully-qualified     # 🎸 E0.6 guitar
 1F3B9                                                  ; fully-qualified     # 🎹 E0.6 musical keyboard
-1F3BA                                                  ; fully-qualified     # 🎺 E0.6 trumpet
 1F3BB                                                  ; fully-qualified     # 🎻 E0.6 violin
 1FA95                                                  ; fully-qualified     # 🪕 E12.0 banjo
 1F941                                                  ; fully-qualified     # 🥁 E3.0 drum
 1FA98                                                  ; fully-qualified     # 🪘 E13.0 long drum
 1FA87                                                  ; fully-qualified     # 🪇 E15.0 maracas
 1FA88                                                  ; fully-qualified     # 🪈 E15.0 flute
+1FA89                                                  ; fully-qualified     # 🪉 E16.0 harp
 
 # subgroup: phone
 1F4F1                                                  ; fully-qualified     # 📱 E0.6 mobile phone
@@ -4206,8 +4694,9 @@
 1F3F7                                                  ; unqualified         # 🏷 E0.7 label
 
 # subgroup: money
-1F4B0                                                  ; fully-qualified     # 💰 E0.6 money bag
 1FA99                                                  ; fully-qualified     # 🪙 E13.0 coin
+1F4B0                                                  ; fully-qualified     # 💰 E0.6 money bag
+1FA8E                                                  ; fully-qualified     # 🪎 E17.0 treasure chest
 1F4B4                                                  ; fully-qualified     # 💴 E0.6 yen banknote
 1F4B5                                                  ; fully-qualified     # 💵 E0.6 dollar banknote
 1F4B6                                                  ; fully-qualified     # 💶 E1.0 euro banknote
@@ -4321,12 +4810,15 @@
 2696                                                   ; unqualified         # ⚖ E1.0 balance scale
 1F9AF                                                  ; fully-qualified     # 🦯 E12.0 white cane
 1F517                                                  ; fully-qualified     # 🔗 E0.6 link
+26D3 FE0F 200D 1F4A5                                   ; fully-qualified     # ⛓️‍💥 E15.1 broken chain
+26D3 200D 1F4A5                                        ; unqualified         # ⛓‍💥 E15.1 broken chain
 26D3 FE0F                                              ; fully-qualified     # ⛓️ E0.7 chains
 26D3                                                   ; unqualified         # ⛓ E0.7 chains
 1FA9D                                                  ; fully-qualified     # 🪝 E13.0 hook
 1F9F0                                                  ; fully-qualified     # 🧰 E11.0 toolbox
 1F9F2                                                  ; fully-qualified     # 🧲 E11.0 magnet
 1FA9C                                                  ; fully-qualified     # 🪜 E13.0 ladder
+1FA8F                                                  ; fully-qualified     # 🪏 E16.0 shovel
 
 # subgroup: science
 2697 FE0F                                              ; fully-qualified     # ⚗️ E1.0 alembic
@@ -4389,8 +4881,8 @@
 1FAA7                                                  ; fully-qualified     # 🪧 E13.0 placard
 1FAAA                                                  ; fully-qualified     # 🪪 E14.0 identification card
 
-# Objects subtotal:		310
-# Objects subtotal:		310	w/o modifiers
+# Objects subtotal:		316
+# Objects subtotal:		316	w/o modifiers
 
 # group: Symbols
 
@@ -4607,6 +5099,7 @@
 00AE                                                   ; unqualified         # ® E0.6 registered
 2122 FE0F                                              ; fully-qualified     # ™️ E0.6 trade mark
 2122                                                   ; unqualified         # ™ E0.6 trade mark
+1FADF                                                  ; fully-qualified     # 🫟 E16.0 splatter
 
 # subgroup: keycap
 0023 FE0F 20E3                                         ; fully-qualified     # #️⃣ E0.6 keycap: #
@@ -4726,8 +5219,8 @@
 1F533                                                  ; fully-qualified     # 🔳 E0.6 white square button
 1F532                                                  ; fully-qualified     # 🔲 E0.6 black square button
 
-# Symbols subtotal:		304
-# Symbols subtotal:		304	w/o modifiers
+# Symbols subtotal:		305
+# Symbols subtotal:		305	w/o modifiers
 
 # group: Flags
 
@@ -4799,6 +5292,7 @@
 1F1E8 1F1F3                                            ; fully-qualified     # 🇨🇳 E0.6 flag: China
 1F1E8 1F1F4                                            ; fully-qualified     # 🇨🇴 E2.0 flag: Colombia
 1F1E8 1F1F5                                            ; fully-qualified     # 🇨🇵 E2.0 flag: Clipperton Island
+1F1E8 1F1F6                                            ; fully-qualified     # 🇨🇶 E16.0 flag: Sark
 1F1E8 1F1F7                                            ; fully-qualified     # 🇨🇷 E2.0 flag: Costa Rica
 1F1E8 1F1FA                                            ; fully-qualified     # 🇨🇺 E2.0 flag: Cuba
 1F1E8 1F1FB                                            ; fully-qualified     # 🇨🇻 E2.0 flag: Cape Verde
@@ -4979,7 +5473,7 @@
 1F1F9 1F1F2                                            ; fully-qualified     # 🇹🇲 E2.0 flag: Turkmenistan
 1F1F9 1F1F3                                            ; fully-qualified     # 🇹🇳 E2.0 flag: Tunisia
 1F1F9 1F1F4                                            ; fully-qualified     # 🇹🇴 E2.0 flag: Tonga
-1F1F9 1F1F7                                            ; fully-qualified     # 🇹🇷 E2.0 flag: Turkey
+1F1F9 1F1F7                                            ; fully-qualified     # 🇹🇷 E2.0 flag: Türkiye
 1F1F9 1F1F9                                            ; fully-qualified     # 🇹🇹 E2.0 flag: Trinidad & Tobago
 1F1F9 1F1FB                                            ; fully-qualified     # 🇹🇻 E2.0 flag: Tuvalu
 1F1F9 1F1FC                                            ; fully-qualified     # 🇹🇼 E2.0 flag: Taiwan
@@ -5012,13 +5506,13 @@
 1F3F4 E0067 E0062 E0073 E0063 E0074 E007F              ; fully-qualified     # 🏴󠁧󠁢󠁳󠁣󠁴󠁿 E5.0 flag: Scotland
 1F3F4 E0067 E0062 E0077 E006C E0073 E007F              ; fully-qualified     # 🏴󠁧󠁢󠁷󠁬󠁳󠁿 E5.0 flag: Wales
 
-# Flags subtotal:		275
-# Flags subtotal:		275	w/o modifiers
+# Flags subtotal:		276
+# Flags subtotal:		276	w/o modifiers
 
 # Status Counts
-# fully-qualified : 3655
-# minimally-qualified : 827
-# unqualified : 242
+# fully-qualified : 3944
+# minimally-qualified : 1029
+# unqualified : 243
 # component : 9
 
 #EOF


### PR DESCRIPTION
https://emojipedia.org/emoji-17.0/

This also imports Emoji 15.1 and 16.0 characters, since the repo was still on Emoji 15.0. The data was regenerated one version at a time so each emoji gets its correct `unicode_version` (15.1: 28 emoji, 16.0: 8, 17.0: 8). Emoji 17.0 also adds skin tone support to :dancers: and :wrestling:, so those entries (and their gendered variants) now have `"skin_tones": true`.

I set the iOS version to 17.4 / 18.4 / 26.4 respectively, since those are the versions where these emoji were added ([source](https://emojipedia.org/apple/)).

Note: Unicode reorganized their site for 17.0, so the `emoji-test.txt` URL in the Rakefile moved from `/Public/emoji/<version>/` to `/Public/17.0.0/emoji/`.