### PR TITLE
Add south_korea alias, korea tags for North Korea

### DIFF
--- a/db/emoji.json
+++ b/db/emoji.json
@@ -21857,6 +21857,8 @@
       "north_korea"
     ]
   , "tags": [
+      "korea"
+    , "north"
     ]
   , "unicode_version": "6.0"
   , "ios_version": "8.3"
@@ -21867,9 +21869,11 @@
   , "category": "Flags"
   , "aliases": [
       "kr"
+    , "south_korea"
     ]
   , "tags": [
       "korea"
+    , "south"
     ]
   , "unicode_version": "6.0"
   , "ios_version": "6.0"


### PR DESCRIPTION
## Add `south_korea` alias, `korea` tags for North Korea

The 🇰🇷 flag has no alias containing either word of its name, so in practice it's reachable
only by typing `kr` exactly.

Current data:

```
🇰🇷  aliases: ["kr"]            tags: ["korea"]
🇰🇵  aliases: ["north_korea"]   tags: []
```

`Emoji.find_by_alias("south_korea")` returns `nil`, and alias-substring search misses it from
both directions:

| Search | Matches today | 🇰🇷 |
| --- | --- | --- |
| `south` | `south_africa`, `south_sudan`, `south_georgia_south_sandwich_islands`, `french_southern_territories` | ❌ no alias contains "south" |
| `korea` | `north_korea` | ❌ "korea" is a tag, not an alias |

South Korea does carry `korea` as a tag, so a tag-aware consumer can find it — but alias lookup
never sees tags, and pickers that do search tags rank those hits below alias matches, so 🇰🇵 wins
the "korea" query. 🇰🇵, meanwhile, has no tags at all, so it isn't findable by tag search either.

### Change

```
🇰🇷  aliases: ["kr", "south_korea"]   tags: ["korea", "south"]
🇰🇵  aliases: ["north_korea"]         tags: ["korea", "north"]
```

Appending the full country name after a short canonical alias follows the existing
`eu`/`european_union` shape. North Korea gets `korea`/`north` tags to close the same gap from
the tag side, without touching its aliases.

After the change, an alias search for `south` returns 5 flags including South Korea, and
`korea` returns both Koreas.

### Notes

- **Existing aliases stay in first position.** `Character#name` is `aliases.first`, so
  `find_by_unicode("🇰🇷").name` still returns `"kr"` and `:kr:` / `:north_korea:` are
  unaffected. Nothing is renamed or removed, and North Korea's alias list is untouched.
- **No collisions.** `south_korea` was unused across all 1870 entries, so the "emojis have
  valid names" duplicate assertion still holds. (For anyone considering the same treatment for
  the other ISO-2 flags: `japan` is already taken by 🗾 and `turkey` by 🦃.)
- **Survives regeneration.** `db/dump.rb` copies `existing_emoji.aliases` and
  `existing_emoji.tags` verbatim, so `rake db:dump` won't clobber these. Both flag sequences
  match on the first `find_by_unicode` lookup and appear exactly once in
  `vendor/unicode-emoji-test.txt`, so the `seen_existing` de-dup path can't regenerate a fresh
  alias for them.
- The diff is 4 added lines in `db/emoji.json`, hand-edited to match the file's generated
  leading-comma formatting.
